### PR TITLE
Convert to openAPI version 3.0.1 and add missing endpoints and parameters

### DIFF
--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -1025,7 +1025,7 @@ paths:
   /keyword_set/:
     get:
       summary: Return as list of keyword_sets for grouping keywords
-      description: Unlike other endpoints, keyword_sets do not support filtering. It is expected that the full result set will remain small enough.
+      description: Unlike other endpoints, keyword_sets do not support filtering. It is expected that the full result set will remain small enough. Recommended keyword_sets are <code>helsinki:topics</code> for general categorization and <code>helsinki:audiences</code> for target grouping.
       operationId: keyword_set_list
       tags:
       - filter
@@ -1270,6 +1270,8 @@ paths:
         keywords in decreasing number of events found. The common keywords
         used in all events originate from the general Finnish ontology (yso),
         hence the format <code>yso:p4354</code>.</p>
+        <p>Recommended keywords for sorting through all events are included in the <code>keyword_sets</code>
+        <code>helsinki:topics</code> (general categorization) and <code>helsinki:audiences</code> (target grouping).</p>
         <p>Example:</p>
         <pre><code>event/?keyword=yso:p4354
         </code></pre>

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -383,9 +383,6 @@ definitions:
       publisher:
         type: string
         description: Organization that provided the location data
-      deleted:
-        type: boolean
-        description: Whether this location has been deleted in the original data source. It may still contain old events linked to it.
       replaced_by:
         "$ref": '#/definitions/place'
 

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -53,7 +53,7 @@ parameters:
   pagesize_param:
     name: page_size
     in: query
-    description: request that server delivers page_size results in response
+    description: request that server delivers page_size results in response. 100 is the maximum value for page_size.
     required: false
     type: integer
   sort:

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -1261,7 +1261,7 @@ paths:
         <pre><code>event/?include=location,keywords
         </code></pre>
         <p><a href="?include=location,keywords" title="json">See the result</a></p>
-        <h2 id="ordering">Ordering</h4>
+        <h2 id="ordering">Ordering</h2>
         <p>Default ordering is decreasing order by <code>last_modified_time</code>.
         You may also order results by <code>start_time</code>, <code>end_time</code>,
         <code>name</code> and <code>duration</code>. For example:</p>

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -382,7 +382,12 @@ definitions:
         description: Identifies the source for data, this is specific to API provider. This is useful for API users, as any data quality issues are likely to be specific to data source and workarounds can be applied as such.
       publisher:
         type: string
-        description: Organization that provided the event that this place is associated with
+        description: Organization that provided the location data
+      deleted:
+        type: boolean
+        description: Whether this location has been deleted in the original data source. It may still contain old events linked to it.
+      replaced_by:
+        "$ref": '#/definitions/place'
 
   image:
     title: Image
@@ -547,6 +552,11 @@ definitions:
         items:
           type: string
         description: FIXME(verify) alternative labels for this keyword, no language specified. Use case?
+      deprecated:
+        type: boolean
+        description: Whether this keyword has been deprecated in the original data source. It may still contain old events linked to it.
+      replaced_by:
+        "$ref": '#/definitions/keyword'
 
   keyword_set:
       title: Keyword set
@@ -786,6 +796,11 @@ definitions:
       publisher:
         type: string
         description: Organization responsible for this event record.
+      deleted:
+        type: boolean
+        description: Whether this event has been deleted in the original data source.
+      replaced_by:
+        "$ref": '#/definitions/event'
       extension_course:
         type: object
         description: Linked Courses extra fields

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -1312,7 +1312,7 @@ paths:
         </code></pre>
         <p><a href="?include=location,keywords" title="json">See the result</a></p>
         <h2 id="ordering">Ordering</h2>
-        <p>Default ordering is descending order by <code>last_modified_time</code>.
+        <p>Default ordering is descending order by <code>-last_modified_time</code>.
         You may also order results by <code>start_time</code>, <code>end_time</code>,
         <code>name</code> and <code>duration</code>. Descending order is denoted by
         adding <code>-</code> in front of the parameter, default order is ascending.

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -1261,6 +1261,14 @@ paths:
         <pre><code>event/?include=location,keywords
         </code></pre>
         <p><a href="?include=location,keywords" title="json">See the result</a></p>
+        <h2 id="ordering">Ordering</h4>
+        <p>Default ordering is decreasing order by <code>last_modified_time</code>.
+        You may also order results by <code>start_time</code>, <code>end_time</code>,
+        <code>name</code> and <code>duration</code>. For example:</p>
+        <pre><code>event/?sort=end_time
+        </code></pre>
+        <p><a href="?sort=name" title="json">See the result</a></p>
+    </div>
       operationId: Event_list
       tags:
       - event

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -1211,14 +1211,18 @@ paths:
         Any events that intersect with the given date range will be returned.</p>
         <p>The parameters <code>start</code> and <code>end</code> can be given in the following formats:</p>
         <ul>
-        <li>ISO 8601 (including the time of day)</li>
+        <li>ISO 8601 (including the time of day), i.e. YYYY-MM-DDTHH:MM:SSZ</li>
         <li>yyyy-mm-dd</li>
         </ul>
-        <p>In addition, <code>today</code> can be used as the value.</p>
+        <p>In addition, <code>today</code> (for start or end of today) and <code>now</code>
+        (for the exact current timestamp) can be used in either parameter to get current events.</p>
         <p>Example:</p>
-        <pre><code>event/?start=2014-01-15&amp;end=2014-01-20
+        <pre><code>event/?start=today&amp;end=2020-12-31
         </code></pre>
-        <p><a href="?start=2014-01-15&amp;end=2014-01-20" title="json">See the result</a></p>
+        <p><a href="?start=today&amp;end=2020-12-31" title="json">See the result</a></p>
+        <pre><code>event/?start=now&amp;end=today
+        </code></pre>
+        <p><a href="?start=now&amp;end=today" title="json">See the result</a></p>
         <h3 id="event-location">Event location</h3>
         <h4 id="bounding-box">Bounding box</h4>
         <p>To restrict the retrieved events to a geographical region, use
@@ -1227,7 +1231,7 @@ paths:
         </code></pre>
         <p>Where <code>west</code> is the longitude of the rectangle's western boundary,
         <code>south</code> is the latitude of the rectangle's southern boundary,
-        and so on.</p>
+        and so on. The coordinate system is the trusty old EPSG:4326 known from all online maps.</p>
         <p>Example:</p>
         <pre><code>event/?bbox=24.9348,60.1762,24.9681,60.1889
         </code></pre>
@@ -1252,7 +1256,7 @@ paths:
         if you wish to query for several divisions.</p>
         <p>City of Helsinki neighborhoods (kaupunginosa), districts (peruspiiri)
         and subdistricts (osa-alue) are supported.
-            <a href="http://kartta.hel.fi/?setlanguage=en&e=25498873&n=6674660&r=16&w=***&l=Karttasarja%2Ckaupunginosat%2Cosaalueet_WFS%2Cperuspiiri_WFS&o=100%2C100%2C100%2C100&swtab=kaikki">
+            <a href="https://kartta.hel.fi/link/8BqeiY">
                 Check the divisions on the Helsinki map service.</a>
         </p>
         <p> You may query either by specific OCD division type <code>peruspiiri:malmi</code>, or by division name
@@ -1265,17 +1269,44 @@ paths:
         <h3 id="event-category">Event category</h3>
         <p>To restrict the retrieved events by category, use the query
         parameter <code>keyword</code>, separating values by commas if you wish to
-        query for several locations.</p>
+        query for any of several keywords, or the parameter <code>keyword_AND</code>, if you require all
+        provided values (separated by commas) to be present.</p>
         <p>Keyword ids are found at the <code>keyword</code> endpoint, which lists the
         keywords in decreasing number of events found. The common keywords
-        used in all events originate from the general Finnish ontology (yso),
+        used in all events originate from the general Finnish ontology (YSO),
         hence the format <code>yso:p4354</code>.</p>
-        <p>Recommended keywords for sorting through all events are included in the <code>keyword_sets</code>
-        <code>helsinki:topics</code> (general categorization) and <code>helsinki:audiences</code> (target grouping).</p>
+        <p>The most common event categories are listed in the two keyword sets
+            <a href="https://api.hel.fi/linkedevents/v1/keyword_set/helsinki:topics/">helsinki:topics</a> and
+            <a href="https://api.hel.fi/linkedevents/v1/keyword_set/helsinki:audiences/">helsinki:audiences</a>,
+        which list the YSO keywords that are present in most events to specify event main topic and audience.</p>
         <p>Example:</p>
         <pre><code>event/?keyword=yso:p4354
         </code></pre>
         <p><a href="?keyword=yso:p4354" title="json">See the result</a></p>
+        <h3 id="event-last-modified">Event last modification time</h3>
+        <p>To find events that have changed since you last polled Linkedevents API (to e.g. update your event cache),
+        it is best to use the query parameter <code>last_modified_since</code>. This allows you to only return data
+        that has changed after your last update. You may also include events that have been deleted in the API in
+        the results by using the <code>show_deleted</code> filter. This allows you to update your cache with all added,
+        modified and deleted events without having to fetch *all* future events every time.</p>
+        </p>
+        </p>
+        <p>Example:</p>
+        <pre><code>event/?last_modified_since=2020-04-07&show_deleted=True
+        </code></pre>
+        <p><a href="?last_modified_since=2020-04-07&show_deleted=True" title="json">See the result</a></p>
+        <h3 id="event-status">Event status</h3>
+        <p>Events in Linkedevents (indicated by the <code>event_status</code> field) may be either scheduled as planned
+        (<code>EventScheduled</code>), rescheduled if their start time has changed after they were first published
+        (<code>EventRescheduled</code>), cancelled if they were cancelled altogether after publication
+        (<code>EventCancelled</code>), or postponed to the indefinite future if they could not be organized at the
+        original time (<code>EventPostponed</code>). These statuses stem from <a href='https://schema.org/eventStatus'>
+        schema.org</a>.</p>
+        <p>You may filter events with only the desired status with the <code>event_status</code> filter.</p>
+        <p>Example:</p>
+        <pre><code>event/?event_status=EventCancelled
+        </code></pre>
+        <p><a href="?event_status=EventCancelled" title="json">See the result</a></p>
         <h3 id="event-text">Event text</h3>
         <p>To find out events that contain a specific string in any of the text
         fields, use the query parameter <code>text</code>.</p>
@@ -1283,7 +1314,16 @@ paths:
         <pre><code>event/?text=shostakovich
         </code></pre>
         <p><a href="?text=shostakovich" title="json">See the result</a></p>
-        <h3 id="event-text">Event language</h3>
+        <h3 id="event-price">Event price</h3>
+        <p>Events may or may not contain the <code>offers</code> field that lists event pricing. To return only
+        free or non-free events, use the query parameter<code>is_free</code>. However, note that from some
+        data sources, no event pricing info is available, so this filter will only return those events which
+        have pricing data available.</p>
+        <p>Example:</p>
+        <pre><code>event/?is_free=true
+        </code></pre>
+        <p><a href="?is_free=true" title="json">See the result</a></p>
+        <h3 id="event-language">Event language</h3>
         <p>To find events that have a set language or event data translated into
         that language, use the query parameter <code>language</code>. If you only wish to see
         events that have a set language, use the <code>in_language</code> parameter, and if
@@ -1296,14 +1336,33 @@ paths:
         <pre><code>event/?language=ru
         </code></pre>
         <p><a href="?language=ru" title="json">See the result</a></p>
-        <h3 id="event-text">Event publisher</h3>
+        <h3 id="event-publisher">Event publisher</h3>
         <p>To find out events that are published by a specific organization, use the query
-        parameter <code>publisher</code>.</p>
-        <p>Existing organizations are found at the <code>organization</code> endpoint.</p>
+        parameter <code>publisher</code>, separating values by commas if you wish to query for several publishers.</p>
+        <p>Existing publisher organizations are found at the <code>organization</code> endpoint. City of Helsinki
+        internal publishers have ids of the form <code>ahjo:origin_id</code> as they originate from
+        the Helsinki Ahjo decisionmaking system, and have a rather complex hierarchy. External publishers may have
+        their own namespaces, ids and hierarchies.</p>
+        <p>Also, it is possible to fetch events under a specific publisher organization hierarchy (say
+        <a href='https://api.hel.fi/linkedevents/v1/organization/ahjo:00001/'>City of Helsinki</a>) by using the
+        parameter <code>publisher_ancestor</code>, which returns all events published by any suborganizations
+        (at any level) of the given organization.</p>
         <p>Example:</p>
         <pre><code>event/?publisher=ytj:0586977-6
         </code></pre>
         <p><a href="?publisher=ytj:0586977-6" title="json">See the result</a></p>
+        <pre><code>event/?publisher_ancestor=ahjo:00001
+        </code></pre>
+        <p><a href="?publisher_ancestor=ahjo:00001" title="json">See the result</a></p>
+        <h3 id="event-data-source">Event data source</h3>
+        <p>To find out events that originate from a specific source system, use the query parameter
+        <code>data_source</code>. All event ids are of the form <code>data_source:origin_id</code>, so this allows
+        you to return only events coming to Linkedevents from a specific data system. <code>helsinki</code> is the
+        name of our own data source, i.e. events where Linkedevents API itself is the master data.</p>
+        <p>Example:</p>
+        <pre><code>event/?data_source=helmet
+        </code></pre>
+        <p><a href="?data_source=helmet" title="json">See the result</a></p>
         <h3 id="event-hierarchy">Event hierarchy</h3>
         <p>Events in linkedevents may be either standalone events, or they may have super or sub
         events. There are two types of super events, indicated in the field
@@ -1335,7 +1394,16 @@ paths:
         <p>In the default case, keywords, locations, and other fields that
         refer to separate resources are only displayed as simple references.</p>
         <p>If you want to include the complete data from related resources in
-        the current response, use the keyword <code>include</code>. For example:</p>
+        the current response, use the keyword <code>include</code>. <strong> Please note, however,
+        that including all the resources inlined in *every* event will result in a huge number
+        of duplicate data in the json, making the json very slow to generate and process and causing
+        considerable API load and long response times when too many such requests are made. Therefore,
+        if you are listing the maximum number of events (100) or updating your cache with all events,
+        please consider caching the keyword and location data separately to prevent unnecessary API
+        slowdown and continuous repeated work. Keyword and location data seldom change and are easily
+        fetched from their own endpoints separately.
+        </strong></p>
+        <p>Example:</p>
         <pre><code>event/?include=location,keywords
         </code></pre>
         <p><a href="?include=location,keywords" title="json">See the result</a></p>

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -1312,12 +1312,14 @@ paths:
         </code></pre>
         <p><a href="?include=location,keywords" title="json">See the result</a></p>
         <h2 id="ordering">Ordering</h2>
-        <p>Default ordering is decreasing order by <code>last_modified_time</code>.
+        <p>Default ordering is descending order by <code>last_modified_time</code>.
         You may also order results by <code>start_time</code>, <code>end_time</code>,
-        <code>name</code> and <code>duration</code>. For example:</p>
-        <pre><code>event/?sort=end_time
+        <code>name</code> and <code>duration</code>. Descending order is denoted by
+        adding <code>-</code> in front of the parameter, default order is ascending.
+        For example:</p>
+        <pre><code>event/?sort=-end_time
         </code></pre>
-        <p><a href="?sort=name" title="json">See the result</a></p>
+        <p><a href="?sort=-end_time" title="json">See the result</a></p>
       operationId: Event_list
       tags:
       - event
@@ -1334,6 +1336,8 @@ paths:
                 items:
                   $ref: '#/definitions/event'
       parameters:
+      - $ref: '#/parameters/page_param'
+      - $ref: '#/parameters/pagesize_param'
       - $ref: '#/parameters/include_param'
       - $ref: '#/parameters/event_text_param'
       - $ref: '#/parameters/event_last_modified_param'

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -96,6 +96,26 @@ parameters:
     description: Search for events that have been modified since or at this time.
     type: string
     format: dateTime
+  event_show_deleted_param:
+    name: show_deleted
+    in: query
+    description: Include deleted events in the query.
+    type: boolean
+  event_event_status_param:
+    name: event_status
+    in: query
+    description: Search for events with the specified status in the event_status field.
+    type: string
+  event_is_free_param:
+    name: is_free
+    in: query
+    description: Search for events that have a price that is free, or not free.
+    type: boolean
+  event_division_param:
+    name: division
+    in: query
+    description: You may filter places by specific OCD division id, or by division name. The latter query checks all divisions with the name, regardless of division type..
+    type: string
   event_bbox_param:
     name: bbox
     in: query
@@ -104,19 +124,19 @@ parameters:
       type: string
     minItems: 4
     maxItems: 4
-    description: Search for events that are within this bounding box. Decimal coordinates are given in order west, south, east, north. Period is used as decimal separator.
+    description: Search for events that are within this bounding box. Decimal coordinates are given in order west, south, east, north. Period is used as decimal separator. Coordinate system is EPSG:4326.
   event_start_param:
     name: start
     in: query
     type: string
     format: date-time
-    description: Search for events beginning or ending after this time. Dates can be specified using ISO 8601 ("2016-01-12") and additionally "today".
+    description: Search for events beginning or ending after this time. Dates can be specified using ISO 8601 ("2016-01-12") and additionally "today" and "now".
   event_end_param:
     name: end
     in: query
     type: string
     format: date-time
-    description: Search for events beginning or ending before this time. Dates can be specified using ISO 8601 ("2016-01-12") and additionally "today".
+    description: Search for events beginning or ending before this time. Dates can be specified using ISO 8601 ("2016-01-12") and additionally "today" and "now".
   event_data_source_param:
     name: data_source
     in: query
@@ -134,6 +154,11 @@ parameters:
     in: query
     type: string
     description: Search for events with given keywords as specified by id. Multiple ids are separated by comma
+  event_keyword_AND_param:
+    name: keyword_AND
+    in: query
+    type: string
+    description: Search for events with all given keywords as specified by id. Multiple ids are separated by comma
   event_min_duration_param:
     name: min_duration
     in: query
@@ -144,11 +169,31 @@ parameters:
     in: query
     type: integer
     description: Search for events that are shorter than given time in seconds
-  event_organization_param:
+  event_language_param:
+    name: language
+    in: query
+    description: Search for events that have data or are organized in this language.
+    type: string
+  event_translation_param:
+    name: translation
+    in: query
+    description: Search for events that have data in this language.
+    type: string
+  event_in_language_param:
+    name: in_language
+    in: query
+    description: Search for events that are organized in this language.
+    type: string
+  event_publisher_param:
     name: publisher
     in: query
     type: string
-    description: Search for events published by the given organization
+    description: Search for events published by the given organization as specified by id.
+  event_publisher_ancestor_param:
+    name: publisher_ancestor
+    in: query
+    type: string
+    description: Search for events published by any suborganization under the given organization as specified by id.
   event_super_event_type_param:
     name: super_event_type
     in: query
@@ -1437,19 +1482,24 @@ paths:
       - $ref: '#/parameters/include_param'
       - $ref: '#/parameters/event_text_param'
       - $ref: '#/parameters/event_last_modified_param'
+      - $ref: '#/parameters/event_show_deleted_param'
+      - $ref: '#/parameters/event_event_status_param'
+      - $ref: '#/parameters/event_is_free_param'
       - $ref: '#/parameters/event_start_param'
       - $ref: '#/parameters/event_end_param'
       - $ref: '#/parameters/event_bbox_param'
       - $ref: '#/parameters/event_data_source_param'
       - $ref: '#/parameters/event_location_param'
-      - name: division
-        in: query
-        type: string
-        description: 'You may filter places by specific OCD division id, or by division name. The latter query checks all divisions with the name, regardless of division type.'
+      - $ref: '#/parameters/event_division_param'
       - $ref: '#/parameters/event_keyword_param'
+      - $ref: '#/parameters/event_keyword_AND_param'
       - $ref: '#/parameters/event_min_duration_param'
       - $ref: '#/parameters/event_max_duration_param'
-      - $ref: '#/parameters/event_organization_param'
+      - $ref: '#/parameters/event_language_param'
+      - $ref: '#/parameters/event_translation_param'
+      - $ref: '#/parameters/event_in_language_param'
+      - $ref: '#/parameters/event_publisher_param'
+      - $ref: '#/parameters/event_publisher_ancestor_param'
       - $ref: '#/parameters/event_super_event_type_param'
       - $ref: '#/parameters/event_super_event_param'
       - $ref: '#/parameters/event_sort_param'

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -134,14 +134,6 @@ parameters:
     in: query
     type: string
     description: Search for events with given keywords as specified by id. Multiple ids are separated by comma
-  event_recurring_param:
-    name: recurring
-    in: query
-    type: string
-    enum:
-      - super
-      - sub
-    description: Search for events based on whether they are part of recurring event set. 'super' specifies recurring, while 'sub' is non-recurring.
   event_min_duration_param:
     name: min_duration
     in: query
@@ -157,6 +149,16 @@ parameters:
     in: query
     type: string
     description: Search for events published by the given organization
+  event_super_event_type_param:
+    name: super_event_type
+    in: query
+    type: string
+    description: Search for events with the given superevent type, including none. Multiple types are separated by comma
+  event_super_event_param:
+    name: super_event
+    in: query
+    type: string
+    description: Search for events with the given superevent as specified by id, including none. Multiple ids are separated by comma
 
 definitions:
 
@@ -1253,6 +1255,54 @@ paths:
         <pre><code>event/?text=shostakovich
         </code></pre>
         <p><a href="?text=shostakovich" title="json">See the result</a></p>
+        <h3 id="event-text">Event language</h3>
+        <p>To find events that have a set language or event data translated into
+        that language, use the query parameter <code>language</code>. If you only wish to see
+        events that have a set language, use the <code>in_language</code> parameter, and if
+        you only want event data translated to a set language, use the <code>translation</code> parameter.</p>
+        <p>Supported languages are found at the <code>language</code> endpoint, which also lists
+        which languages have translations available. Currently, translations are supported
+        in <code>fi</code>, <code>sv</code>, <code>en</code>, <code>ru</code>,
+        <code>zh_hans</code>, and <code>ar</code>.</p>
+        <p>Example:</p>
+        <pre><code>event/?language=ru
+        </code></pre>
+        <p><a href="?language=ru" title="json">See the result</a></p>
+        <h3 id="event-text">Event publisher</h3>
+        <p>To find out events that are published by a specific organization, use the query
+        parameter <code>publisher</code>.</p>
+        <p>Existing organizations are found at the <code>organization</code> endpoint.</p>
+        <p>Example:</p>
+        <pre><code>event/?publisher=ytj:0586977-6
+        </code></pre>
+        <p><a href="?publisher=ytj:0586977-6" title="json">See the result</a></p>
+        <h3 id="event-hierarchy">Event hierarchy</h3>
+        <p>Events in linkedevents may be either standalone events, or they may have super or sub
+        events. There are two types of super events, indicated in the field
+        <code>super_event_type</code> by <code>recurring</code> (repeating events, event series)
+        and <code>umbrella</code> (festivals etc.).</p>
+        <p><code>recurring</code> events last for a period and have <code>sub_events</code> that all
+        have similar data, but different dates.</p>
+        <p><code>umbrella</code> events last for a period and may have different
+        <code>sub_events</code>, including <code>recurring</code> events (i.e. an
+        <code>umbrella</code> festival may have a <code>recurring</code> theater play
+        <code>sub_event</code>, which may have several nights as <code>sub_events</code>.)</p>
+        <h4 id="super-event-type">Super event type</h4>
+        <p>You may use the query parameter <code>super_event_type</code>, comma separated, to get
+        only super events of specific types. You may use <code>none</code> if you want non-super
+        events included.</p>
+        <p>Example:</p>
+        <pre><code>event/?super_event_type=umbrella,none
+        </code></pre>
+        <p><a href="?super_event_type=umbrella,none" title="json">See the result</a></p>
+        <h4 id="super-event-type">Super event</h4>
+        <p>You may use the query parameter <code>super_event</code>, comma separated, to get all
+        subevents for specific superevents. You may use <code>none</code> if you want all
+        events which have no superevent included.</p>
+        <p>Example:</p>
+        <pre><code>event/?super_event=linkedevents:agg-103
+        </code></pre>
+        <p><a href="?super_event=linkedevents:agg-103" title="json">See the result</a></p>
         <h2 id="getting-detailed-data">Getting detailed data</h2>
         <p>In the default case, keywords, locations, and other fields that
         refer to separate resources are only displayed as simple references.</p>
@@ -1301,6 +1351,8 @@ paths:
       - $ref: '#/parameters/event_min_duration_param'
       - $ref: '#/parameters/event_max_duration_param'
       - $ref: '#/parameters/event_organization_param'
+      - $ref: '#/parameters/event_super_event_type_param'
+      - $ref: '#/parameters/event_super_event_param'
       - $ref: '#/parameters/event_sort_param'
 
     post:

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -1,1749 +1,2912 @@
----
-swagger: '2.0'
-
+openapi: 3.0.1
 info:
   title: Linked Events information API
   description: |-
-      Linked Events provides categorized data on events and places using JSON-LD format.
+    Linked Events provides categorized data on events and places using JSON-LD format.
 
-      Events can be searched by date and location. Location can be exact address or larger
-      area such as neighbourhood or borough
+    Events can be searched by date and location. Location can be exact address or larger
+    area such as neighbourhood or borough
 
-      JSON-LD format is streamlined using include mechanism. API users can request that certain
-      fields are included directly into the result, instead of being hyperlinks to objects.
+    JSON-LD format is streamlined using include mechanism. API users can request that certain
+    fields are included directly into the result, instead of being hyperlinks to objects.
 
-      Several fields are multilingual. These are implemented as object with each language variant
-      as property. In this specification each multilingual field has (fi,sv,en) property triplet as
-      example.
-
-  termsOfService: (depends on data provider)
+    Several fields are multilingual. These are implemented as object with each language variant
+    as property. In this specification each multilingual field has (fi,sv,en) property triplet as
+    example.
   version: v1
-
-# Helsinki implementation is ok for seeing how API works. It has extra fields and endpoints
-# compared to this specification
-host: api.hel.fi
-basePath: /linkedevents/v1
-
-schemes:
-  - https
-  - http
-
-produces:
-  - application/json
-
+servers:
+  - url: https://api.hel.fi/linkedevents/v1
+  - url: http://api.hel.fi/linkedevents/v1
 tags:
   - name: event
     description: Search and edit events
-  - name: filter
-    description: Browse keywords, places and publishers for filtering events
   - name: search
     description: Fulltext search through events and places
-  - name: language
-    description: Get supported languages
   - name: image
     description: Get and upload images
-
-parameters:
-  page_param:
-    name: page
-    in: query
-    description: request particular page in paginated results
-    required: false
-    type: integer
-  pagesize_param:
-    name: page_size
-    in: query
-    description: request that server delivers page_size results in response. 100 is the maximum value for page_size.
-    required: false
-    type: integer
-  sort:
-    name: sort
-    in: query
-    description: return the results in ascending or descending order by the named field. sorting is only supported for some string, integer and datetime fields.
-    required: false
-    type: string
-  event_sort_param:
-    name: sort
-    in: query
-    type: string
-    description: Sort the returned events in the given order. Possible sorting criteria are 'start_time', 'end_time', 'duration' and 'last_modified_time'. The default ordering is '-last_modified_time'.
-  place_sort_param:
-    name: sort
-    in: query
-    type: string
-    description: Sort the returned places in the given order. Possible sorting criteria are 'n_events', 'id', 'name', 'street_address' and 'postal_code'. The default ordering is '-n_events'.
-  keyword_sort_param:
-    name: sort
-    in: query
-    type: string
-    description: Sort the returned keywords in the given order. Possible sorting criteria are 'n_events', 'id', 'name', 'data_source'. The default ordering is '-data_source', '-n_events'.
-  include_param:
-    name: include
-    in: query
-    type: string
-    description: Embed given reference-type fields, comma-separated if several, directly into the response, otherwise they are returned as URI references.
-  event_text_param:
-    name: text
-    in: query
-    description: Search (case insensitive) through all multilingual text fields (name, description, short_description, info_url) of an event (every language). Multilingual fields contain the text that users are expected to care about, thus multilinguality is useful discriminator.
-    required: false
-    type: string
-  event_last_modified_param:
-    name: last_modified_since
-    in: query
-    description: Search for events that have been modified since or at this time.
-    type: string
-    format: dateTime
-  event_show_deleted_param:
-    name: show_deleted
-    in: query
-    description: Include deleted events in the query.
-    type: boolean
-  event_event_status_param:
-    name: event_status
-    in: query
-    description: Search for events with the specified status in the event_status field.
-    type: string
-  event_is_free_param:
-    name: is_free
-    in: query
-    description: Search for events that have a price that is free, or not free.
-    type: boolean
-  event_division_param:
-    name: division
-    in: query
-    description: You may filter places by specific OCD division id, or by division name. The latter query checks all divisions with the name, regardless of division type..
-    type: string
-  event_bbox_param:
-    name: bbox
-    in: query
-    type: array
-    items:
-      type: string
-    minItems: 4
-    maxItems: 4
-    description: Search for events that are within this bounding box. Decimal coordinates are given in order west, south, east, north. Period is used as decimal separator. Coordinate system is EPSG:4326.
-  event_start_param:
-    name: start
-    in: query
-    type: string
-    format: date-time
-    description: Search for events beginning or ending after this time. Dates can be specified using ISO 8601 ("2016-01-12") and additionally "today" and "now".
-  event_end_param:
-    name: end
-    in: query
-    type: string
-    format: date-time
-    description: Search for events beginning or ending before this time. Dates can be specified using ISO 8601 ("2016-01-12") and additionally "today" and "now".
-  event_data_source_param:
-    name: data_source
-    in: query
-    type: string
-    description: Search for events that come from the specified source system
-  event_location_param:
-    name: location
-    in: query
-    type: string
-    description: Search for events in given locations as specified by id. Multiple ids are separated by comma
-  event_keyword_param:
-    name: keyword
-    in: query
-    type: string
-    description: Search for events with given keywords as specified by id. Multiple ids are separated by comma
-  event_keyword_AND_param:
-    name: keyword_AND
-    in: query
-    type: string
-    description: Search for events with all given keywords as specified by id. Multiple ids are separated by comma
-  event_min_duration_param:
-    name: min_duration
-    in: query
-    type: integer
-    description: Search for events that are longer than given time in seconds
-  event_max_duration_param:
-    name: max_duration
-    in: query
-    type: integer
-    description: Search for events that are shorter than given time in seconds
-  event_language_param:
-    name: language
-    in: query
-    description: Search for events that have data or are organized in this language.
-    type: string
-  event_translation_param:
-    name: translation
-    in: query
-    description: Search for events that have data in this language.
-    type: string
-  event_in_language_param:
-    name: in_language
-    in: query
-    description: Search for events that are organized in this language.
-    type: string
-  event_publisher_param:
-    name: publisher
-    in: query
-    type: string
-    description: Search for events published by the given organization as specified by id.
-  event_publisher_ancestor_param:
-    name: publisher_ancestor
-    in: query
-    type: string
-    description: Search for events published by any suborganization under the given organization as specified by id.
-  event_super_event_type_param:
-    name: super_event_type
-    in: query
-    type: string
-    description: Search for events with the given superevent type, including none. Multiple types are separated by comma
-  event_super_event_param:
-    name: super_event
-    in: query
-    type: string
-    description: Search for events with the given superevent as specified by id, including none. Multiple ids are separated by comma
-
-definitions:
-
-  meta_definition:
-    title: Meta
-    description: Meta record for result pagination. All results from API are paginated, ie. delivered in chunks of X results. This records describes how many results there are in total, and how to access previous and next pages.
-    type: object
-    properties:
-      count:
-        description: Total amount of items found
-        type: integer
-      next:
-        description: URL for the next page of items
-        type: string
-        format: url
-      previous:
-        description: URL for the previous page of items
-        type: string
-        format: url
-
-  place:
-    type: object
-    title: Place
-    description: Places describe physical locations for events and means for contacting people responsible for these locations. Place definitions come from organizations publishing events (field "publisher") and can thus have slightly different semantics between places sourced from different organizations.
-    required:
-    - name
-    - position
-    properties:
-      id:
-        type: string
-        description: Consists of source prefix and source specific identifier. These should be URIs uniquely identifying the place, and preferably also well formed http-URLs pointing to more information about the place.
-      custom_data:
-        type: array
-        description: 'Key value field for custom data. FIXME: is there 6Aika-wide use case for this?'
-        items:
-          type: object
-          properties:
-            key:
-              type: string
-            value:
-              type: string
-      name:
-        type: object
-        description: Name of the place, multilingual
-        properties:
-          fi:
-            type: string
-            description: place name in Finnish
-          sv:
-            type: string
-            description: place name in Swedish
-          en:
-            type: string
-            description: place name in English
-      images:
-        type: array
-        items:
-          "$ref": '#/definitions/image'
-      origin_id:
-        type: string
-        description: 'Place identifier in the originating system. Same as id but without the data source prefix.'
-      created_time:
-        type: string
-        format: date-time
-        description: 'Creation time for the place entry.'
-      last_modified_time:
-        type: string
-        format: date-time
-        description: 'Time this place was modified in the datastore behind the API (not necessarily in the originating system)'
-      # No examples of the translated representation, probably same as with other multilingual fields.
-      info_url:
-        description: Link (URL) to a page with more information about place
-        type: object
-        properties:
-          fi:
-            description: Link to Finnish page
-            type: string
-            format: url
-          se:
-            description: Link to Swedish page
-            type: string
-            format: url
-          en:
-            description: Link to English page
-            type: string
-            format: url
-      description:
-        description: 'Short (? FIXME: perhaps specify recommendation) description of the place, multilingual.'
-        type: object
-        properties:
-          fi:
-            type: string
-            description: place description in Finnish
-          sv:
-            type: string
-            description: place description in Swedish
-          en:
-            type: string
-            description: place description in English
-      position:
-        description: geographic position of the place specified using subset of GeoJSON
-        type: object
-        properties:
-          coordinates:
-            description: coordinates in format specified by type property
-            type: array
-            items:
-              type: number
-          type:
-            description: interpretation of the coordinates property. Only point is supported in this version
-            type: string
-            enum:
-            - Point
-      email:
-        type: string
-        description: Contact email for the place, note that this is NOT multilingual
-      telephone:
-        type: object
-        description: Contact phone number for the place, multilingual
-        properties:
-          fi:
-            type: string
-            description: phone number for Finnish speakers
-          sv:
-            type: string
-            description: phone number for Swedish speakers
-          en:
-            type: string
-            description: phone number for English speakers
-      contact_type:
-        type: string
-        description: 'FIXME: this seems unused in Helsinki data. Does any 6Aika city have use for describing contact type?'
-      street_address:
-        description: Street address for the place, multilingual
-        type: object
-        properties:
-          fi:
-            type: string
-            description: address in Finnish
-          sv:
-            type: string
-            description: address in Swedish
-          en:
-            type: string
-            description: address in English
-      address_locality:
-        description: Describes where the address is located, typically this would be name of the city
-        type: object
-        properties:
-          fi:
-            type: string
-            description: locality in Finnish
-          sv:
-            type: string
-            description: locality in Swedish
-          en:
-            type: string
-            description: locality in English
-      address_region:
-        type: string
-        description: Larger region for address (like states), not typically used in Finland
-      postal_code:
-        type: string
-        description: Postal code of the location (as used by traditional mail)
-      post_office_box_num:
-        type: string
-        description: PO box for traditional mail, in case mail is not delivered to the building
-      address_country:
-        type: string
-        description: Country for the place, NOT multilingual
-      deleted:
-        type: boolean
-        description: This place entry is not used anymore, but old events still reference it. This might be because of duplicate removal.
-      data_source:
-        type: string
-        description: Identifies the source for data, this is specific to API provider. This is useful for API users, as any data quality issues are likely to be specific to data source and workarounds can be applied as such.
-      publisher:
-        type: string
-        description: Organization that provided the location data
-      replaced_by:
-        "$ref": '#/definitions/place'
-
-  image:
-    title: Image
-    description: Images are used as pictures for events, places and organizers.
-    type: object
-    required:
-    - url
-    properties:
-      name:
-        type: object
-        properties:
-          fi:
-            type: string
-            description: Image description in Finnish
-          sv:
-            type: string
-            description: Image description in Swedish
-          en:
-            type: string
-            description: Image description in English
-      publisher:
-        type: string
-        description: The organization responsible for the image.
-      created_time:
-        type: string
-        format: date-time
-        description: 'Creation time for the image.'
-      last_modified_time:
-        type: string
-        format: date-time
-        description: 'Time this image was modified in the datastore behind the API (not necessarily in the originating system)'
-      created_by:
-        type: string
-        description: URL reference to the user that created this record (user endpoint)
-      last_modified_by:
-        type: string
-        description: URL reference to the user that last modfied this record (user endpoint)
-      url:
-        type: string
-        description: The image file URL.
-      cropping:
-        type: string
-        description: Cropping data for the image.
-      license:
-        type: string
-        description: License data for the image. May be "cc_by" (default) or "event_only". The latter license restricts use of the image and is specified on the API front page.
-
-  organization:
-    title: Organization
-    description: Organizations are the entities that publish events and other data.
-    type: object
-    required:
-    - id
-    - name
-    - data source
-    properties:
-      id:
-        type: string
-        description: Consists of source prefix and source specific identifier. These should be URIs uniquely identifying the organization, and preferably also well formed http-URLs pointing to more information about the organization.
-      name:
-        type: string
-        description: The name of the organization.
-      origin_id:
-        type: string
-        description: Identifier for the organization in the original data source. For standardized namespaces this will be a shared identifier.
-      created_time:
-        type: string
-        format: date-time
-        description: 'Creation time for the organization information.'
-      last_modified_time:
-        type: string
-        format: date-time
-        description: 'Time this organization was modified in the datastore behind the API (not necessarily in the originating system)'
-      data_source:
-        type: string
-        description: Source of the organization data, typically API provider specific identifier. Will also be used to specify standardized namespaces as they are brought into use.
-      classification:
-        type: string
-        description: Id of the organization type.
-      founding_date:
-        type: string
-        format: date-time
-        description: 'Time the organization was founded.'
-      dissolution_date:
-        type: string
-        format: date-time
-        description: 'Time the organization was dissolved. If present, the organization no longer exists.'
-      is_affiliated:
-        type: boolean
-        description: Whether the organization is an affiliated organization of the parent, instead of a proper suborganization.
-      replaced_by:
-        "$ref": '#/definitions/organization'
-      has_regular_users:
-        type: boolean
-        description: Whether the organization has non-admin users in addition to admin users.
-      parent_organization:
-        "$ref": '#/definitions/organization'
-      sub_organizations:
-        type: array
-        description: The organizations that belong to this organization.
-        items:
-          "$ref": '#/definitions/organization'
-      affiliated_organizations:
-        type: array
-        description: The organizations that are affiliated partners to this organization, but not proper suborganizations.
-        items:
-          "$ref": '#/definitions/organization'
-
-  keyword:
-    title: Keyword
-    description: Keywords are used to describe events. Linked events uses namespaced keywords in order to support having events from different sources. Namespaces are needed because keywords are defined by the organization sourcing the events and can therefore overlap in meaning. Conversely the meaning of same keyword can vary between organizations. Organization sourcing the keyword can be identified by data_source field. Data_source field will later specify standardized namespaces as well.
-    type: object
-    required:
-    - id
-    - name
-    - data_source
-    properties:
-      id:
-        type: string
-        description: Consists of source prefix and source specific identifier. These should be URIs uniquely identifying the keyword, and preferably also well formed http-URLs pointing to more information about the keyword.
-      name:
-        type: object
-        properties:
-          fi:
-            type: string
-            description: Keyword in Finnish
-          sv:
-            type: string
-            description: Keyword in Swedish
-          en:
-            type: string
-            description: Keyword in English
-      images:
-        type: array
-        items:
-          "$ref": '#/definitions/image'
-      origin_id:
-        type: string
-        description: Identifier for the keyword in the organization using this keyword. For standardized namespaces this will be a shared identifier.
-      publisher:
-        type: string
-        description: Id of the organization that has originally published this keyword.
-      created_time:
-        type: string
-        format: date-time
-        description: 'Creation time for the keyword entry.'
-      last_modified_time:
-        type: string
-        format: date-time
-        description: 'Time this place was modified in the datastore behind the API (not necessarily in the originating system)'
-      aggregate:
-        type: boolean
-        description: FIXME(verify) This keyword is an combination of several keywords at source
-      data_source:
-        type: string
-        description: Source of the keyword, typically API provider specific identifier. Will also be used to specify standardized namespaces as they are brought into use.
-      created_by:
-        type: string
-        description: FIXME(verify) URL reference to the user that created this record (user endpoint)
-      last_modified_by:
-        type: string
-        description: FIXME(verify) URL reference to the user that last modfied this record (user endpoint)
-      alt_labels:
-        type: array
-        items:
-          type: string
-        description: FIXME(verify) alternative labels for this keyword, no language specified. Use case?
-      deprecated:
-        type: boolean
-        description: Whether this keyword has been deprecated in the original data source. It may still contain old events linked to it.
-      replaced_by:
-        "$ref": '#/definitions/keyword'
-
-  keyword_set:
-      title: Keyword set
-      description: Keyword sets are used to group keywords together into classification groups. For example, one set of keywords might describe themes used by an event provider and another could be used to describe audience groups.
-      type: object
-      required:
-      - id
-      - name
-      - keywords
-      properties:
-        id:
-          type: string
-          description: Unique identifier for this keyword_set. These should be URIs identifying the source and the keyword_set itself, and preferably also well formed http-URLs pointing to more information about the keyword.
-        name:
-          type: string
-          description: Name for this keyword_set. This should be human readable, such that it could be shown as label in UI
-        origin_id:
-          type: string
-          description: 'Set identifier in the originating system, if any'
-        created_time:
-          type: string
-          format: date-time
-          description: Time when this keyword_set was created (ISO 8601)
-        last_modified_time:
-          type: string
-          format: date-time
-          description: Time when this keyword_set was last modified (ISO 8601)
-        data_source:
-          type: string
-          description: Unique identifier (URI)for the system where this keyword_set originated, if any
-        last_modified_by:
-          type: string
-          description: FIXME(verify) Which API user most recently edited this keyword
-        usage:
-          type: string
-          description: 'Usage type for this keyword_set. These are allow UIs to show the set in appropriate place. FIXME: set of types is not finalized by any stretch'
-          enum:
-          - any
-          - keyword
-          - audience
-        organization:
-          type: string
-          description: Organization that has defined this keyword_set
-        keywords:
-          type: array
-          description: Keywords that belong to this keyword_set
-          items:
-            "$ref": '#/definitions/keyword'
-  language:
-    title: Languages supported in this API
-    type: object
-    description: Primary purpose of this endpoint is to allow users to identify which languages are supported for multilingual fields. It also has translations for the names of the languages.
-    required:
-    - id
-    - name
-    properties:
-      id:
-        type: string
-        description: Identifier for the language (typically ISO639-1)
-      name:
-        type: object
-        description: Translation for the language name. Properties shown here are examples, it is suggested that every language supported has its name translated to every other language. Users of the API cannot rely on any translations being present.
-        properties:
-          fi:
-            description: Name of the language in Finnish
-            type: string
-          se:
-            description: Name of the language in Swedish
-            type: string
-          en:
-            description: Name of the language in English
-            type: string
-
-  event:
-    title: Events
-    type: object
-    description: 'Describes the actual events. Linked events API supports organizing events into hierarchies. This is implemented with collection events called "super events". Super events are normal event objects, that reference contained events in "sub_events" property. Currently there are two major use cases: events such as "Helsinki Festival", which consist of unique events over a span of time and recurring events such as theatrical productions with multiple showings. It is implementation dependent how the grouping of events is done. It should be noted that grouping might be automatic based on eg. event name and thus group unrelated events together and miss related events. Users of data are advised to prepare for this.'
-    required:
-    - name
-    - location
-    - start_time
-    - keywords
-    - publication_status
-    properties:
-      id:
-        description: consists of source prefix and source specific identifier. These should be URIs uniquely identifying the event, and preferably also well formed http-URLs pointing to more information about the event.
-        type: string
-      location:
-        "$ref": '#/definitions/place'
-      keywords:
-        description: The keywords that describe the topic and type of this event.
-        type: array
-        items:
-          "$ref": '#/definitions/keyword'
-      in_language:
-        description: the languages spoken or supported at the event
-        type: array
-        items:
-          "$ref": '#/definitions/language'
-      super_event:
-        description: references the aggregate event containing this event
-        type: string
-      super_event_type:
-        description: If the event has sub_events, describes the type of the event. Current options are 'null', 'recurring', which means a repeating event, and 'umbrella', which means a major event that has subevents.
-        type: string
-      event_status:
-        type: string
-        description: As defined in schema.org/Event. Postponed events do not have a date set, rescheduled events have been moved to different date.
-      publication_status:
-        type: string
-        description: Only available in POST/PUT. Specifies whether the event should be published in the API ('public') or not ('draft').
-      external_links:
-        type: array
-        items:
-          "$ref": '#/definitions/eventlink'
-        description: See external link definition
-      offers:
-        type: array
-        items:
-          "$ref": '#/definitions/offer'
-        description: See offer definition
-      sub_events:
-        type: array
-        items:
-          "$ref": '#/definitions/event'
-        description: for aggregate events this contains references to all sub events. Usually this means that the sub events are part of series. The field 'super_event_type' tells the type of the aggregate event.
-      custom_data:
-        type: string
-        description: 'Key value field for custom data. FIXME: is there 6Aika-wide use case for this?'
-      name:
-        type: object
-        description: 'Short descriptive name for the event, recommended limit: 80 characters'
-        properties:
-          fi:
-            description: Name of the event in Finnish
-            type: string
-          se:
-            description: Name of the event in Swedish
-            type: string
-          en:
-            description: Name of the event in English
-            type: string
-      images:
-        type: array
-        items:
-          "$ref": '#/definitions/image'
-      created_time:
-        type: string
-        format: date-time
-        description: 'Creation time for the event entry.'
-      last_modified_time:
-        type: string
-        format: date-time
-        description: 'Time this event was modified in the datastore behind the API (not necessarily in the originating system)'
-      info_url:
-        description: Link (URL) to a page with more information about event
-        type: object
-        properties:
-          fi:
-            description: Link to Finnish page
-            type: string
-            format: url
-          se:
-            description: Link to Swedish page
-            type: string
-            format: url
-          en:
-            description: Link to English page
-            type: string
-            format: url
-      description:
-        type: object
-        description: Long description for the event, several chapters
-        properties:
-          fi:
-            description: Finnish description of the event
-          se:
-            description: Swedish description of the event
-          en:
-            description: English description of the event
-      short_description:
-        type: object
-        description: Short description for the event, recommended limit 140 characters
-        properties:
-          fi:
-            description: short Finnish description of the event
-          se:
-            description: short Swedish description of the event
-          en:
-            description: short English description of the event
-      date_published:
-        type: string
-        format: date-time
-        description: Date this event is free to be published
-      provider:
-        type: object
-        description: Description of who is responsible for the practical implementation of the event
-        properties:
-          fi:
-            description: provider name in Finnish for the event
-          se:
-            description: provider name in Swedish for the event
-          en:
-            description: provider name in English for the event
-      location_extra_info:
-        type: object
-        description: Unstructured extra info about location (like "eastern door of railway station")
-        properties:
-          fi:
-            description: location extra info in Finnish for the event
-          se:
-            description: location extra info in Swedish for the event
-          en:
-            description: location extra info in English for the event
-      start_time:
-        type: string
-        format: date-time
-        description: Time the event will start
-      end_time:
-        type: string
-        format: date-time
-        description: Time the event will end
-      audience:
-        description: The audience groups (picked from keywords) this event is intended for
-        type: array
-        items:
-          "$ref": '#/definitions/keyword'
-      data_source:
-        type: string
-        description: Unique identifier (URI)for the system from which this event came from, preferably URL with more information about the system and its policies
-      created_by:
-        type: string
-        description: Name and email of the user who created this event. Only available for authorized users in the publisher organization hierarchy.
-      last_modified_by:
-        type: string
-        description: Name and email of the user who last edited this event. Only available for authorized users in the publisher organization hierarchy.
-      publisher:
-        type: string
-        description: Id for the organization that published this event in Linkedevents.
-      deleted:
-        type: boolean
-        description: Whether this event has been deleted in the original data source.
-      replaced_by:
-        "$ref": '#/definitions/event'
-      extension_course:
-        type: object
-        description: Linked Courses extra fields
-        properties:
-          enrolment_start_time:
-            type: string
-            format: date-time
-            description: Time enrolment for the course will start
-            example: "2018-08-01T08:00:00Z"
-          enrolment_end_time:
-            type: string
-            format: date-time
-            description: Time enrolment for the course will end
-            example: "2018-08-31T18:00:00Z"
-          maximum_attendee_capacity:
-            type: integer
-            description: Maximum number of people allowed to enrol for the course
-            example: 100
-          minimum_attendee_capacity:
-            type: integer
-            description: Minimum number of people required to enrol for the course
-            example: 10
-          remaining_attendee_capacity:
-            type: integer
-            description: Number of people still allowed to enrol for the course before it is full
-            example: 50
-  offer:
-    title: Price offers
-    description: information record for this event. The prices are not in a structured format and the format depends on information source. An exception to this is the case of free event. These are indicated using is_free flag, which is searchable.
-    type: object
-    properties:
-      price:
-        type: object
-        description: Price of the event. These are not bare numbers but instead descriptions of the pricing scheme.
-        properties:
-          fi:
-            type: string
-            description: Finnish translation for the price information
-          sv:
-            type: string
-            description: Swedish translation for the price information
-          en:
-            type: string
-            description: English translation for the price information
-      info_url:
-        description: Link (URL) to a page with more information about offer
-        type: object
-        properties:
-          fi:
-            description: Link to Finnish page
-            type: string
-            format: url
-          se:
-            description: Link to Swedish page
-            type: string
-            format: url
-          en:
-            description: Link to English page
-            type: string
-            format: url
-      description:
-        type: object
-        description: Further description of the pricing
-        properties:
-          fi:
-            type: string
-            description: Finnish price description
-          sv:
-            type: string
-            description: Swedish price description
-          en:
-            type: string
-            description: English price description
-      is_free:
-        type: boolean
-        description: Whether the event is of free admission
-
-  eventlink:
-    title: Links to related information
-    description: Links to entities that the event publisher considers related to this event. Eg. links to catering service available during theatrical production. The links will most likely point to unstructured content, ie. web pages suitable for human viewing.
-    type: object
-    properties:
-      name:
-        type: string
-        description: Name describing contents of the link
-      link:
-        type: string
-        description: link to an external related entity
-      language:
-        type: string
-        description: language of the content behind the link
+  - name: keyword
+    description: Search and edit keywords
+  - name: keyword set
+    description: Search and edit keyword sets
+  - name: organization
+    description: Search and edit organizations
+  - name: place
+    description: Search and edit places
+  - name: language
+    description: Get supported languages
+  - name: data source
+    description: Get supported data sources
+  - name: organization class
+    description: Get supported organization classes
 
 paths:
   /search/:
     get:
+      tags:
+        - search
       summary: Search through events and places
       description: |
         <h2 id="using-search-endpoint">Using the search endpoint</h2>
-        <p>This is the supposedly intelligent Elasticsearch Finnish full-text search for both events and places.
-            The results are sorted by relevance score shown in the <code>score</code> field. The search parameter is <code>?q=</code>.
+        <p>This is the supposedly intelligent Elasticsearch Finnish full-text search for both events and places. The results are sorted by relevance score shown in the <code>score</code> field. The search parameter is <code>?q=</code>.
+
         <h4 id="specifying-resource-type">Specifying resource type</h4>
-        <p>In the default case, both events and places are returned. The type of each resource is returned in the
-            <code>resource_type</code> field. You may use the parameter <code>type</code> to ask for only <code>event</code> or <code>place</code>.
+        <p>In the default case, both events and places are returned. The type of each resource is returned in the <code>resource_type</code> field. You may use the parameter <code>type</code> to ask for only <code>event</code> or <code>place</code>.
+
         <h4 id="events-with-decay-score">Future events with time decay</h4>
-        <p>When searching for events only (<code>?type=event</code>), by default only future events are returned, with a decay function applied so that next
-            events get a higher relevance score. This means that
-            events in the near future are returned first:</p>
-        <pre><code>search/?type=event&q=sibelius
-        </code></pre>
-        <p><a href="?type=event&q=sibelius" title="json">See the result</a></p>
+        <p>When searching for events only (<code>?type=event</code>), by default only future events are returned, with a decay function applied so that next events get a higher relevance score. This means that events in the near future are returned first:</p> 
+        <pre><code>search/?type=event&q=sibelius</code></pre>
+
         <h4 id="events-with-time-filtering">Events with time filtering</h4>
-        <p>When searching for events only (<code>?type=event</code>), you may also search for events in the specified time range using
-            <code>start</code> or <code>end</code> or both. In this case, relevance score
-        is calculated only based on Finnish tokenization of the search string, with no time preference:</p>
-        <pre><code>search/?type=event&q=sibelius&start=2017-01-01
-        </code></pre>
-        <p><a href="?type=event&q=sibelius&start=2017-01-01" title="json">See the result</a></p>
+        <p>When searching for events only (<code>?type=event</code>), you may also search for events in the specified time range using <code>start</code> or <code>end</code> or both. In this case, relevance score is calculated only based on Finnish tokenization of the search string, with no time preference:</p>
+        <pre><code>search/?type=event&q=sibelius&start=2017-01-01</code></pre>
+
         <h4 id="autocomplete">Autocomplete</h4>
-                <p>For fast autocomplete substring match in the resource name, use the <code>?input=</code> parameter instead.
-                    When searching for events only (<code>?type=event</code>), by default only future events are returned, with a decay function applied so that next
-            events get a higher relevance score. May be combined with <code>start</code> and <code>end</code>.
-        <pre><code>search/?type=place&input=sibe
-        </code></pre>
-        <p><a href="?type=event&input=sibe" title="json">See the result</a></p>
+        <p>For fast autocomplete substring match in the resource name, use the <code>?input=</code> parameter instead. When searching for events only (<code>?type=event</code>), by default only future events are returned, with a decay function applied so that next events get a higher relevance score. May be combined with <code>start</code> and <code>end</code>.
+        <pre><code>search/?type=place&input=sibe</code></pre>
       operationId: event_search
-      tags:
-      - search
       parameters:
-        - $ref: '#/parameters/page_param'
-        - $ref: '#/parameters/pagesize_param'
+        - $ref: "#/components/parameters/page_param"
+        - $ref: "#/components/parameters/pagesize_param"
         - name: type
           in: query
-          type: string
           description: Comma-delimited list of resource types to search for. Currently allowed values are `event` and `place`. `type=event` must be specified for event date filtering and relevancy sorting.
+          schema:
+            type: string
         - name: q
           in: query
-          type: string
           description: Search for events and places matching this string. Mutually exclusive with `input` typeahead search.
+          schema:
+            type: string
         - name: input
           in: query
-          type: string
           description: Return autocompletition suggestions for this string. Mutually exclusive with `q` full-text search.
-        - $ref: '#/parameters/event_start_param'
-        - $ref: '#/parameters/event_end_param'
-
+          schema:
+            type: string
+        - $ref: "#/components/parameters/event_start_param"
+        - $ref: "#/components/parameters/event_end_param"
       responses:
         200:
           description: List of resources
-          schema:
-            type: object
-            properties:
-              meta:
-                $ref: '#/definitions/meta_definition'
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/event'
-
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  meta:
+                    $ref: "#/components/schemas/meta_definition"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/event"
   /image/:
     get:
+      tags:
+        - image
       summary: Returns a list of images
       description: |
-        Image endpoint returns images that are used for events, places or organizers.
+        <h2 id="using-image-endpoint">Using the image endpoint</h2>
+        <p>Here, images for events are listed. Default ordering is decreasing order by <code>-last_modified_time</code>.</p>
+        <h4 id="image-text">Image text</h4>
+        <p>To find images that contain a specific string, use the query parameter <code>text</code>.</p>
+        <p>Example:</p>
+        <pre><code>image/?text=lapset</code></pre>
+
+        <h3 id="image-publisher">Image publisher</h3>
+        <p>To find out images that are published by a specific organization, use the query parameter <code>publisher</code>, separating values by commas if you wish to query for several publishers.</p>
+        <p>Existing publisher organizations are found at the <code>organization</code> endpoint.</p>
+        <p>Example:</p>
+        <pre><code>image/?publisher=ytj:0586977-6</code></pre>
+
+        <h3 id="image-data-source">Image data source</h3>
+        <p>To find out images that originate from a specific source system, use the query parameter <code>data_source</code>, separating values by commas if you wish to query for several data sources.</p>
+        <p>Example:</p>
+        <pre><code>image/?data_source=helmet</code></pre>
+
+        <h4 id="ordering">Ordering</h4>
+        <p>Default ordering is descending order by <code>-last_modified_time</code>. You may also order results by <code>id</code> and <code>name</code>.</p>
+        <p>For example:</p>
+        <pre><code>image/?sort=name</code></pre>
       operationId: image_list
-      tags:
-      - image
       parameters:
-        - $ref: '#/parameters/page_param'
-        - $ref: '#/parameters/pagesize_param'
-        - $ref: '#/parameters/include_param'
-        - $ref: '#/parameters/sort'
+        - $ref: "#/components/parameters/page_param"
+        - $ref: "#/components/parameters/pagesize_param"
+        - $ref: "#/components/parameters/include_param"
+        - $ref: "#/components/parameters/image_text_param"
+        - $ref: "#/components/parameters/image_publisher_param"
+        - $ref: "#/components/parameters/image_data_source_param"
+        - $ref: "#/components/parameters/image_sort_param"
 
       responses:
         200:
           description: List of images
-          schema:
-            type: object
-            properties:
-              meta:
-                $ref: '#/definitions/meta_definition'
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/image'
-
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  meta:
+                    $ref: "#/components/schemas/meta_definition"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/image"
     post:
-      summary: Create a new image
-      operationId: image_create
-      description: There are two ways to create an image object. The image file can be posted as a multipart request, but the endpoint also accepts a simple JSON object with an external url in the url field. This allows using external images for events without saving them on the API server.
       tags:
-      - image
-      consumes:
-      - multipart/form-data
+        - image
+      summary: Create a new image
+      description: There are two ways to create an image object. The image file can be posted as a multipart request, but the endpoint also accepts a simple JSON object with an external url in the url field. This allows using external images for events without saving them on the API server.
+      operationId: image_create
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                image_file:
+                  type: string
+                  format: binary
       responses:
         201:
-          description: Object has been succesfully created. A copy of the object is returned in response body and headers contain Location pointing to the created event
-          schema:
-            $ref: '#/definitions/image'
+          description: Object has been succesfully created. A copy of the object is returned in response body and headers contain Location pointing to the created event.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/image"
         400:
-          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed
+          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed.
+          content: {}
         401:
-          description: User was not authenticated
+          description: User was not authenticated.
+          content: {}
         403:
-          description: User does not have necessary permissions
-      parameters:
-      - name: image_file
-        in: formData
-        type: file
-
+          description: User does not have necessary permissions.
+          content: {}
   /image/{id}/:
     get:
+      tags:
+        - image
       summary: Return information for single image
       operationId: image_retrieve
-      tags:
-      - image
+      parameters:
+        - name: id
+          in: path
+          description: The id for the image
+          required: true
+          schema:
+            type: string
       responses:
         200:
           description: Image record
-          schema:
-            $ref: '#/definitions/image'
-      parameters:
-      - type: string
-        description: The id for the image
-        in: path
-        name: id
-        required: true
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/image"
     put:
+      tags:
+        - image
       summary: Update an image
       description: Images can be updated if the user has appropriate access permissions. The original implementation behaves like PATCH, ie. if some field is left out from the PUT call, its value is retained in database. In order to ensure consistent behaviour, users should always supply every field in PUT call.
       operationId: image_update
-      tags:
-      - image
+      parameters:
+        - name: id
+          in: path
+          description: Identifier for the image to be updated
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Image object that should replace the existing image, note that some implementations may retain unspecified fields at their original values.
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/image"
+        required: false
       responses:
         200:
-          description: Image has been succesfully replaced
-          schema:
-            $ref: '#/definitions/image'
+          description: Image has been succesfully replaced.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/image"
         400:
-          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed
+          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed.
+          content: {}
         401:
-          description: User was not authenticated
+          description: User was not authenticated.
+          content: {}
         403:
-          description: User does not have necessary permissions
+          description: User does not have necessary permissions.
+          content: {}
+      x-codegen-request-body-name: image_object
+    delete:
+      tags:
+        - image
+      summary: Delete an image
+      description: Image can be deleted if the user has appropriate access permissions.
+      operationId: image_delete
       parameters:
-      - type: string
-        in: path
-        name: id
-        required: true
-        description: Identifier for the image to be updated
-      - name: image_object
-        in: body
-        description: Image object that should replace the existing image, note that some implementations may retain unspecified fields at their original values.
-        schema:
-          $ref: '#/definitions/image'
-
-
+        - name: id
+          in: path
+          description: Identifier for the image to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        204:
+          description: Image has been successfully deleted.
+          content: {}
+        401:
+          description: User was not authenticated.
+          content: {}
+        403:
+          description: User does not have necessary permissions.
+          content: {}
   /keyword/:
     get:
+      tags:
+        - keyword
       summary: Returns a list of keywords used for describing events
       description: |
         <h2 id="using-keyword-endpoint">Using the keyword endpoint</h2>
-        <p>Here, categories for events are listed. Events in each category can be found at the
-        <code>event</code> endpoint using the query parameter <code>keyword</code>. The common keywords
-        used in all events originate from the <a href="https://finto.fi/yso/en/">general Finnish ontology (yso)</a>,
-        hence the format <code>yso:p4354</code>. Default ordering is decreasing order by the number of events found.</p>
+        <p>Here, categories for events are listed. Events in each category can be found at the <code>event</code> endpoint using the query parameter <code>keyword</code>. The common keywords used in all events originate from the <a href="https://finto.fi/yso/en/">general Finnish ontology (yso)</a>, hence the format <code>yso:p4354</code>. Default ordering is decreasing order by the number of events found.</p>
+        <p>The most common event categories are listed in the two keyword sets <a href="https://api.hel.fi/linkedevents/v1/keyword_set/helsinki:topics/">helsinki:topics</a> and <a href="https://api.hel.fi/linkedevents/v1/keyword_set/helsinki:audiences/">helsinki:audiences</a>, which list the YSO keywords that are present in most events to specify event main topic and audience.</p>
+
         <h4 id="keyword-text">Keyword text</h4>
         <p>To find keywords that contain a specific string, use the query parameter <code>text</code>.</p>
         <p>Example:</p>
-        <pre><code>keyword/?text=lapset
-        </code></pre>
-        <p><a href="?text=lapset" title="json">See the result</a></p>
+        <pre><code>keyword/?text=lapset</code></pre>
+
+        <h4 id="keyword-text">Free text</h4>
+        <p>While the previous search is looking for the keywords containg exact matches of the search string, <code>free_text</code> retrieves keywords on the basis of similarity. Results are sorted by similarity.</p>
+        <p>Example:</p>
+        <pre><code>keyword/?free_text=lapppset</code></pre>
+
         <h4 id="keyword-source">Keyword source</h4>
         <p>Will restrict keywords to a specific data source.</p>
         <p>Example:</p>
-        <pre><code>keyword/?data_source=yso
-        </code></pre>
-        <p><a href="?data_source=yso" title="json">See the result</a></p>
-        <h4 id="ordering">Ordering</h4>
-        <p>Default ordering is decreasing order by the number of events found. You may also order results by <code>name</code>.
-        <p>Example:</p>
-        <pre><code>keyword/?sort=name
-        </code></pre>
-        <p><a href="?sort=name" title="json">See the result</a></p>
-        <h4 id="showing-all-keyword">Showing all keywords</h4>
-        <p>By default, only those keywords which have listed events are
-        displayed. You may display keywords with zero <code>n_events</code> with the
-            query parameter <code>show_all_keywords</code>.</p>
-      operationId: keyword_list
-      tags:
-      - filter
-      parameters:
-        - $ref: '#/parameters/page_param'
-        - $ref: '#/parameters/pagesize_param'
-        - $ref: '#/parameters/include_param'
-        # FIXME: use case for 6Aika cities
-        - name: show_all_keywords
-          in: query
-          type: boolean
-          description: 'Show all keywords, including those that are not associated with any events. Otherwise such keywords are hidden. When show_all_keywords is specified, no other filter is applied, **except** "filter" (match for keywords beginning with string)'
-        - name: data_source
-          in: query
-          type: string
-          description: 'Search for keywords (**note**: NOT events) that come from the specified data source (see data source in keyword definition).'
-        - name: text
-          in: query
-          type: string
-          description: 'Search for keywords (**note**: NOT events) that contain the given string. This applies even when show_all_keywords is specified.'
-        - $ref: '#/parameters/keyword_sort_param'
+        <pre><code>keyword/?data_source=yso</code></pre>
 
+        <h4 id="show-keywords-with-upcoming-events">Show only keywords with the upcoming events</h4>
+        <p>To show only the keywords which are used in the upcoming events supply the <code>has_upcoming_events</code> query parameter.</p>
+        <p>For example:</p>
+        <pre><code>keyword/?has_upcoming_events=True</code></pre>
+
+        <h4 id="showing-all-keyword">Showing all keywords</h4>
+        <p>By default, only those keywords which have listed events are displayed. You may display keywords with zero <code>n_events</code> with the query parameter <code>show_all_keywords</code>.</p>
+        <p>For example:</p>
+        <pre><code>keyword/?show_all_keywords=True</code></pre>
+
+        <h4 id="showing-deprecated-keyword">Showing deprecated keywords</h4>
+        <p>By default, deprecated keywords are not displayed. You may also display deprecated keywords with the query parameter <code>show_deprecated</code>.</p>
+        <p>For example:</p>
+        <pre><code>keyword/?show_deprecated=True</code></pre>
+
+        <h4 id="ordering">Ordering</h4>
+        <p>Default ordering is decreasing order by the number of events found. You may also order results by <code>name</code>.</p>
+        <p>For example:</p>
+        <pre><code>keyword/?sort=name</code></pre>
+      operationId: keyword_list
+      parameters:
+        - $ref: "#/components/parameters/page_param"
+        - $ref: "#/components/parameters/pagesize_param"
+        - $ref: "#/components/parameters/include_param"
+        - $ref: "#/components/parameters/keyword_text_param"
+        - $ref: "#/components/parameters/keyword_free_text_param"
+        - $ref: "#/components/parameters/keyword_data_source_param"
+        - $ref: "#/components/parameters/keyword_has_upcoming_event_param"
+        - $ref: "#/components/parameters/keyword_show_all_keywords_param"
+        - $ref: "#/components/parameters/keyword_show_deprecated_param"
+        - $ref: "#/components/parameters/keyword_sort_param"
       responses:
         200:
           description: List of keywords
-          schema:
-            type: object
-            properties:
-              meta:
-                $ref: '#/definitions/meta_definition'
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/keyword'
-
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  meta:
+                    $ref: "#/components/schemas/meta_definition"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/keyword"
+    post:
+      summary: Create a new keyword
+      operationId: keyword_create
+      requestBody:
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/keyword"
+        required: false
+      tags:
+        - keyword
+      responses:
+        201:
+          description: Keyword has been succesfully created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/keyword"
+        400:
+          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed.
+          content: {}
+        401:
+          description: User was not authenticated.
+          content: {}
+        403:
+          description: User does not have necessary permissions.
+          content: {}
   /keyword/{id}/:
     get:
+      tags:
+        - keyword
       summary: Return information for single keyword
       operationId: keyword_retrieve
-      tags:
-      - filter
+      parameters:
+        - name: id
+          in: path
+          description: Same as id in keyword schema
+          required: true
+          schema:
+            type: string
       responses:
         200:
           description: Keyword record
-          schema:
-            $ref: '#/definitions/keyword'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/keyword"
+    put:
+      tags:
+        - keyword
+      summary: Update a keyword
+      description: |
+        Keyword can be updated if the user has appropriate access permissions. The original implementation behaves like PATCH, ie. if some field is left out from the PUT call, its value is retained in database. In order to ensure consistent behaviour, users should always supply every field in PUT call.
+      operationId: keyword_update
       parameters:
-      - type: string
-        description: Same as id in keyword schema
-        in: path
-        name: id
-        required: true
-
+        - name: id
+          in: path
+          description: Identifier for the keyword to be updated
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        description: Keyword object that should replace the existing keyword.
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/keyword"
+        required: false
+      responses:
+        200:
+          description: Keyword has been succesfully replaced
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/keyword"
+        400:
+          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed.
+          content: {}
+        401:
+          description: User was not authenticated.
+          content: {}
+        403:
+          description: User does not have necessary permissions.
+          content: {}
+      x-codegen-request-body-name: keyword_object
+    delete:
+      tags:
+        - keyword
+      summary: Delete a keyword
+      description: Keyword can be deleted if the user has appropriate access permissions.
+      operationId: keyword_delete
+      parameters:
+        - name: id
+          in: path
+          description: Identifier for the keyword to be deleted
+          required: true
+          schema:
+            type: integer
+      responses:
+        204:
+          description: Keyword has been successfully deleted.
+          content: {}
+        401:
+          description: User was not authenticated.
+          content: {}
+        403:
+          description: User does not have necessary permissions.
+          content: {}
   /keyword_set/:
     get:
-      summary: Return as list of keyword_sets for grouping keywords
-      description: Unlike other endpoints, keyword_sets do not support filtering. It is expected that the full result set will remain small enough. Recommended keyword_sets are <code>helsinki:topics</code> for general categorization and <code>helsinki:audiences</code> for target grouping.
-      operationId: keyword_set_list
       tags:
-      - filter
+        - keyword set
+      summary: Return as list of keyword sets for grouping keywords
+      description: |
+        <h2 id="using-keyword-set-endpoint">Using the keyword set endpoint</h2>
+        <p>Here, the preferred sets of common keywords are listed.</p>
+        <p>We recommend using the 20 piece keyword set <code>helsinki:topics</code> for general event grouping and <code>helsinki:audiences</code> for sorting by target group. These sets are used by the City of Helsinki in categorizing the majority of events in the API.</p>
+
+        <h3 id="text">Search keyword sets</h3>
+        <p>Search keyword sets by id and name. Covers Finnish, English and Swedish name.</p>
+        <p>Example:</p>
+        <pre><code>keyword_set/?text=topic</code></pre>
+
+        <h3 id="sort">Sorting keyword sets</h3>
+        <p>It is possible to sort the keyword sets by <code>name</code>, <code>usage</code>, and <code>id</code> in either ascending or descending order.</p>
+        <p>Example:</p>
+        <pre><code>keyword_set/?sort=id</code></pre>
+      operationId: keyword_set_list
       parameters:
-        - $ref: '#/parameters/page_param'
-        - $ref: '#/parameters/pagesize_param'
-        - $ref: '#/parameters/include_param'
+        - $ref: "#/components/parameters/page_param"
+        - $ref: "#/components/parameters/pagesize_param"
+        - $ref: "#/components/parameters/include_param"
+        - $ref: "#/components/parameters/keyword_set_text_param"
+        - $ref: "#/components/parameters/keyword_set_sort_param"
       responses:
         200:
           description: List of keyword_sets
-          schema:
-            type: object
-            properties:
-              meta:
-                $ref: '#/definitions/keyword'
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/keyword_set'
-
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  meta:
+                    $ref: "#/components/schemas/keyword"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/keyword_set"
+    post:
+      summary: Create a new keyword set
+      operationId: keyword_set_create
+      requestBody:
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/keyword_set"
+        required: false
+      tags:
+        - keyword set
+      responses:
+        201:
+          description: Keyword set has been succesfully created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/keyword_set"
+        400:
+          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed.
+          content: {}
+        401:
+          description: User was not authenticated.
+          content: {}
+        403:
+          description: User does not have necessary permissions.
+          content: {}
   /keyword_set/{id}:
     get:
-      summary: Return information about single keyword_set
-      operationId: keyword_set_retrieve
       tags:
-      - filter
+        - keyword set
+      summary: Return information about single keyword set
+      operationId: keyword_set_retrieve
       parameters:
-        - type: string
-          description: Same as id in keyword_set schema
+        - name: id
           in: path
-          name: id
+          description: Same as id in keyword set schema
           required: true
+          schema:
+            type: string
       responses:
         200:
-          description: Keyword_set record
+          description: Keyword set record
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/keyword_set"
+    put:
+      tags:
+        - keyword set
+      summary: Update a keyword set
+      description: |
+        Keyword set can be updated if the user has appropriate access permissions. The original implementation behaves like PATCH, ie. if some field is left out from the PUT call, its value is retained in database. In order to ensure consistent behaviour, users should always supply every field in PUT call.
+      operationId: keyword_set_update
+      parameters:
+        - name: id
+          in: path
+          description: Identifier for the keyword set to be updated
+          required: true
           schema:
-            $ref: '#/definitions/keyword_set'
-
+            type: integer
+      requestBody:
+        description: Keyword set object that should replace the existing keyword set.
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/keyword_set"
+        required: false
+      responses:
+        200:
+          description: Keyword set has been succesfully replaced.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/keyword_set"
+        400:
+          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed.
+          content: {}
+        401:
+          description: User was not authenticated.
+          content: {}
+        403:
+          description: User does not have necessary permissions.
+          content: {}
+      x-codegen-request-body-name: keyword_set_object
+    delete:
+      tags:
+        - keyword set
+      summary: Delete a keyword set
+      description: Keyword set can be deleted if the user has appropriate access permissions.
+      operationId: keyword_set_delete
+      parameters:
+        - name: id
+          in: path
+          description: Identifier for the keyword set to be deleted
+          required: true
+          schema:
+            type: integer
+      responses:
+        204:
+          description: Keyword set has been successfully deleted.
+          content: {}
+        401:
+          description: User was not authenticated.
+          content: {}
+        403:
+          description: User does not have necessary permissions.
+          content: {}
   /organization/:
     get:
+      tags:
+        - organization
       summary: Returns a list of organizations that publish events
       description: |
         <h2 id="using-organization-endpoint">Using the organization endpoint</h2>
-        <p>Here, the event publisher organizations are listed. Events published by each organization
-            can be found at the <code>event</code> endpoint using the query parameter <code>publisher</code>.</p>
-      operationId: organization_list
-      tags:
-      - filter
-      parameters:
-        - $ref: '#/parameters/page_param'
-        - $ref: '#/parameters/pagesize_param'
-        - name: child
-          in: query
-          type: string
-          description: 'Get the parent organization and all its ancestors for the given organization id.'
-        - name: parent
-          in: query
-          type: string
-          description: 'Get all suborganizations and their descendants for the given organization id.'
+        <p>Here, the event publisher organizations are listed. Events published by each organization can be found at the <code>event</code> endpoint using the query parameter <code>publisher</code>.</p>
 
+        <h4 id="organization-child">Organization ancestors</h4>
+        <p>To find parent organization and all its ancestors for the given organization id use the query parameter <code>child</code>.</p>
+        <p>Example:</p>
+        <pre><code>organization/?child=ahjo:100</code></pre>
+        <p><a href="?child=ahjo:100" title="json">See the result</a></p>
+
+        <h4 id="organization-parent">Organization descendants</h4>
+        <p>To find all suborganizations and their descendants for the given organization id use the query parameter <code>parent</code>.</p>
+        <p>Example:</p>
+        <pre><code>organization/?parent=ahjo:100</code></pre>
+        <p><a href="?parent=ahjo:100" title="json">See the result</a></p>
+      operationId: organization_list
+      parameters:
+        - $ref: "#/components/parameters/page_param"
+        - $ref: "#/components/parameters/pagesize_param"
+        - $ref: "#/components/parameters/organization_child_param"
+        - $ref: "#/components/parameters/organization_parent_param"
       responses:
         200:
           description: List of organizations
-          schema:
-            type: object
-            properties:
-              meta:
-                $ref: '#/definitions/meta_definition'
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/organization'
-
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  meta:
+                    $ref: "#/components/schemas/meta_definition"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/organization"
+    post:
+      summary: Create an organization
+      operationId: organization_create
+      requestBody:
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/organization_payload"
+        required: false
+      tags:
+        - organization
+      responses:
+        201:
+          description: Organization has been succesfully created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/organization"
+        400:
+          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed.
+          content: {}
+        401:
+          description: User was not authenticated.
+          content: {}
+        403:
+          description: User does not have necessary permissions.
+          content: {}
   /organization/{id}:
     get:
+      tags:
+        - organization
       summary: Return information for single organization
       operationId: organization_retrieve
-      tags:
-      - filter
+      parameters:
+        - name: id
+          in: path
+          description: Same as id in organization schema
+          required: true
+          schema:
+            type: string
       responses:
         200:
           description: Organization record
-          schema:
-            $ref: '#/definitions/organization'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/organization"
+    put:
+      tags:
+        - organization
+      summary: Update an organization
+      description: |
+        Organization can be updated if the user has appropriate access permissions. The original implementation behaves like PATCH, ie. if some field is left out from the PUT call, its value is retained in database. In order to ensure consistent behaviour, users should always supply every field in PUT call.
+      operationId: organization_update
       parameters:
-      - type: string
-        description: Same as id in organization schema
-        in: path
-        name: id
-        required: true
-
+        - name: id
+          in: path
+          description: Identifier for the organization to be updated
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        description: Organization object that should replace the existing organization.
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/organization_payload"
+        required: false
+      responses:
+        200:
+          description: Organization has been succesfully replaced.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/organization"
+        400:
+          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed.
+          content: {}
+        401:
+          description: User was not authenticated.
+          content: {}
+        403:
+          description: User does not have necessary permissions.
+          content: {}
+      x-codegen-request-body-name: organization_object
+    delete:
+      tags:
+        - organization
+      summary: Delete an organization
+      description: Organization can be deleted if the user has appropriate access permissions.
+      operationId: organization_delete
+      parameters:
+        - name: id
+          in: path
+          description: Identifier for the organization to be deleted
+          required: true
+          schema:
+            type: integer
+      responses:
+        204:
+          description: Organization has been successfully deleted.
+          content: {}
+        401:
+          description: User was not authenticated.
+          content: {}
+        403:
+          description: User does not have necessary permissions.
+          content: {}
   /place/:
     get:
+      tags:
+        - place
       summary: Returns list of places used for describing events
       description: |
         <h2 id="using-place-endpoint">Using the place endpoint</h2>
-        <p>Here, locations for events are listed. Events in each location can be found at the
-        <code>event</code> endpoint using the query parameter <code>location</code>. Most locations
-            originate from the <a href="https://servicemap.hel.fi">Helsinki service point registry (tprek)</a>, hence
-        the id format <code>tprek:28473</code>. An easy way to locate service points is
-                to browse our <a href="https://servicemap.hel.fi">Service Map</a>, which uses the same location ids,
-        e.g. <code>servicemap.hel.fi/unit/28473</code>. Default ordering is decreasing order by the number of events found.</p>
+        <p>Here, locations for events are listed. Events in each location can be found at the <code>event</code> endpoint using the query parameter <code>location</code>. Most locations use the id format <code>tprek:28473</code>. An easy way to locate service points is to browse our <a href="https://servicemap.hel.fi">Service Map</a>, which uses the same location ids, e.g. <code>servicemap.hel.fi/unit/28473</code>. Default ordering is decreasing order by the number of events found.</p>
+
         <h4 id="place-text">Place text</h4>
         <p>To find places that contain a specific string, use the query parameter <code>text</code>.</p>
         <p>Example:</p>
-        <pre><code>place/?text=tuomiokirkko
-        </code></pre>
-        <p><a href="?text=tuomiokirkko" title="json">See the result</a></p>
+        <pre><code>place/?text=tuomiokirkko</code></pre>
+
         <h4 id="district">District</h4>
-        <p>To restrict the retrieved places to city district(s), use the
-        query parameter <code>division</code>, separating values by commas
-        if you wish to query for several divisions.</p>
-        <p>City of Helsinki neighborhoods (kaupunginosa), districts (peruspiiri)
-        and subdistricts (osa-alue) are supported.
-            <a href="http://kartta.hel.fi/?setlanguage=en&e=25498873&n=6674660&r=16&w=***&l=Karttasarja%2Ckaupunginosat%2Cosaalueet_WFS%2Cperuspiiri_WFS&o=100%2C100%2C100%2C100&swtab=kaikki">
-                Check the divisions on the Helsinki map service.</a>
-        </p>
-        <p>You may query either by specific OCD division type <code>peruspiiri:malmi</code>, or by division name
-        <code>malmi</code>. The latter query checks all divisions with the name,
-        regardless of division type.</p>
+        <p>To restrict the retrieved places to city district(s), use the query parameter <code>division</code>, separating values by commas if you wish to query for several divisions.</p>
+        <p>City of Helsinki neighborhoods (kaupunginosa), districts (peruspiiri) and subdistricts (osa-alue) are supported. <a href="http://kartta.hel.fi/?setlanguage=en&e=25498873&n=6674660&r=16&w=***&l=Karttasarja%2Ckaupunginosat%2Cosaalueet_WFS%2Cperuspiiri_WFS&o=100%2C100%2C100%2C100&swtab=kaikki"> Check the divisions on the Helsinki map service.</a></p>
+        <p>You may query either by specific OCD division type <code>peruspiiri:malmi</code>, or by division name <code>malmi</code>. The latter query checks all divisions with the name, regardless of division type.</p>
         <p>Example:</p>
-        <pre><code>place/?division=malmi
-        </code></pre>
-        <p><a href="?division=malmi" title="json">See the result</a></p>
-        <h4 id="ordering">Ordering</h4>
-        <p>Default ordering is decreasing order by the number of events found.
-            You may also order results by <code>name</code>, <code>street_address</code> or <code>postal_code</code>.
-            For example:</p>
-        <pre><code>place/?sort=name
-        </code></pre>
-        <p><a href="?sort=name" title="json">See the result</a></p>      
+        <pre><code>place/?division=malmi</code></pre>
+
         <h4 id="place-source">Place source</h4>
         <p>Will restrict places to a specific data source.</p>
         <p>Example:</p>
-        <pre><code>place/?data_source=tprek
-        </code></pre>
-        <p><a href="?data_source=tprek" title="json">See the result</a></p>
-        <h4 id="showing-all-places">Showing all places</h4>
-        <p>By default, only those locations which have listed events are
-        displayed. You may display locations with zero <code>n_events</code> with the
-            query parameter <code>show_all_places</code>.</p>
-      operationId: place_list
-      tags:
-      - filter
-      parameters:
-        - $ref: '#/parameters/page_param'
-        - $ref: '#/parameters/pagesize_param'
-        - name: show_all_places
-          in: query
-          type: boolean
-          description: 'Show all places, including those that are not hosting any events. Otherwise such places are hidden. When show_all_places is specified, no other filter is applied.'
-        - name: division
-          in: query
-          type: string
-          description: 'You may filter places by specific OCD division id, or by division name. The latter query checks all divisions with the name, regardless of division type.'
-        - $ref: '#/parameters/place_sort_param'
+        <pre><code>place/?data_source=tprek</code></pre>
 
+        <h4 id="show-places-with-upcoming-events">Show only places with the upcoming events</h4>
+        <p>To show only the places which are used in the upcoming events supply the <code>has_upcoming_events</code> query parameter.</p>
+        <p>Example:</p>
+        <pre><code>place/?has_upcoming_events=true</code></pre>
+            
+        <h4 id="showing-all-places">Showing all places</h4>
+        <p>By default, only those locations which have listed events are displayed. You may display locations with zero <code>n_events</code> with the query parameter <code>show_all_places</code>.</p>
+        <p>Example:</p>
+
+        <h4 id="showing-deleted-places">Showing deleted places</h4>
+        <p>By default, deleted places are not displayed. You may also display deleted places with the query parameter <code>show_deleted</code>.</p>
+        <p>For example:</p>
+        <pre><code>keyword/?show_deleted=True</code></pre>
+
+        <h4 id="ordering">Ordering</h4>
+        <p>Default ordering is decreasing order by the number of events found. You may also order results by <code>name</code>, <code>street_address</code> or <code>postal_code</code>.</p>
+        <p>For example:</p>
+        <pre><code>place/?sort=name</code></pre>
+      operationId: place_list
+      parameters:
+        - $ref: "#/components/parameters/page_param"
+        - $ref: "#/components/parameters/pagesize_param"
+        - $ref: "#/components/parameters/place_text_param"
+        - $ref: "#/components/parameters/place_division_param"
+        - $ref: "#/components/parameters/place_data_source_param"
+        - $ref: "#/components/parameters/place_has_upcoming_event_param"
+        - $ref: "#/components/parameters/place_show_all_places_param"
+        - $ref: "#/components/parameters/place_show_deleted_param"
+        - $ref: "#/components/parameters/place_sort_param"
       responses:
         200:
           description: List of places
-          schema:
-            type: object
-            properties:
-              meta:
-                $ref: '#/definitions/meta_definition'
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/place'
-
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  meta:
+                    $ref: "#/components/schemas/meta_definition"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/place"
+    post:
+      summary: Create a new place
+      operationId: place_create
+      requestBody:
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/place"
+        required: false
+      tags:
+        - place
+      responses:
+        201:
+          description: Place has been succesfully created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/place"
+        400:
+          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed.
+          content: {}
+        401:
+          description: User was not authenticated.
+          content: {}
+        403:
+          description: User does not have necessary permissions.
+          content: {}
   /place/{id}/:
     get:
+      tags:
+        - place
       summary: Return information for single place
       operationId: place_retrieve
-      tags:
-      - filter
+      parameters:
+        - name: id
+          in: path
+          description: Id as defined in place model
+          required: true
+          schema:
+            type: string
       responses:
         200:
           description: Place record
-          schema:
-            $ref: '#/definitions/place'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/place"
+    put:
+      tags:
+        - place
+      summary: Update a place
+      description: |
+        Place can be updated if the user has appropriate access permissions. The original implementation behaves like PATCH, ie. if some field is left out from the PUT call, its value is retained in database. In order to ensure consistent behaviour, users should always supply every field in PUT call.
+      operationId: place_update
       parameters:
-      - type: string
-        in: path
-        name: id
-        required: true
-        description: Id as defined in place model
-
+        - name: id
+          in: path
+          description: Identifier for the place set to be updated
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        description: Place object that should replace the existing place.
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/place"
+        required: false
+      responses:
+        200:
+          description: Place has been succesfully replaced.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/place"
+        400:
+          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed.
+          content: {}
+        401:
+          description: User was not authenticated.
+          content: {}
+        403:
+          description: User does not have necessary permissions.
+          content: {}
+      x-codegen-request-body-name: place_object
+    delete:
+      tags:
+        - place
+      summary: Delete a place
+      description: Place can be deleted if the user has appropriate access permissions.
+      operationId: place_delete
+      parameters:
+        - name: id
+          in: path
+          description: Identifier for the place to be deleted
+          required: true
+          schema:
+            type: integer
+      responses:
+        204:
+          description: Place has been successfully deleted.
+          content: {}
+        401:
+          description: User was not authenticated.
+          content: {}
+        403:
+          description: User does not have necessary permissions.
+          content: {}
   /language/:
     get:
-      summary: Return a list of languages used for describing events
-      description: The returned list describes languages used for describing events in this Linked events instance
-      operationId: language_list
       tags:
-      - language
+        - language
+      summary: Return a list of languages used for describing events
+      description: The returned list describes languages used for describing events in this Linked events instance.
+      operationId: language_list
+      parameters:
+        - $ref: "#/components/parameters/page_param"
+        - $ref: "#/components/parameters/pagesize_param"
       responses:
         200:
           description: Language list
-          schema:
-            type: object
-            properties:
-              meta:
-                $ref: '#/definitions/meta_definition'
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/language'
-
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  meta:
+                    $ref: "#/components/schemas/meta_definition"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/language"
   /language/{id}/:
     get:
-      summary: Return information for single language
-      description: Can be used to retrieve translations for a single language
-      operationId: language_retrieve
       tags:
-      - language
+        - language
+      summary: Return information for single language
+      description: Can be used to retrieve translations for a single language.
+      operationId: language_retrieve
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         200:
           description: Language record
-          schema:
-            $ref: '#/definitions/language'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/language"
+  /data_source/:
+    get:
+      tags:
+        - data source
+      summary: Return a list of data source
+      description: The returned list describes data sources. Only admin users are allowed to use this endpoint.
+      operationId: data_source_list
       parameters:
-      - type: string
-        in: path
-        name: id
-        required: true
-
+        - $ref: "#/components/parameters/page_param"
+        - $ref: "#/components/parameters/pagesize_param"
+      responses:
+        200:
+          description: Data source list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  meta:
+                    $ref: "#/components/schemas/meta_definition"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/data_source"
+  /data_source/{id}/:
+    get:
+      tags:
+        - data source
+      summary: Return information for single data source
+      description: Can be used to retrieve a single data source. Only admin users are allowed to use this endpoint.
+      operationId: data_source_retrieve
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Data source record
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/data_source"
+  /organization_class/:
+    get:
+      tags:
+        - organization class
+      summary: Return a list of organization classes
+      description: The returned list describes organization classes used for organization classification. Only admin users are allowed to use this endpoint.
+      operationId: organization_class_list
+      parameters:
+        - $ref: "#/components/parameters/page_param"
+        - $ref: "#/components/parameters/pagesize_param"
+      responses:
+        200:
+          description: Organization class list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  meta:
+                    $ref: "#/components/schemas/meta_definition"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/organization_class"
+  /organization_class/{id}/:
+    get:
+      tags:
+        - organization class
+      summary: Return information for single organization class
+      description: Can be used to retrieve a single organization class. Only admin users are allowed to use this endpoint.
+      operationId: organization_class_retrieve
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Organization class record
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/organization_class"
   /event/:
     get:
+      tags:
+        - event
       summary: Return a list of events
       description: |-
         <h2 id="filtering-retrieved-events">Filtering retrieved events</h2>
-        <p>Query parameters can be used to filter the retrieved events by
-        the following criteria.</p>
+        <p>Query parameters can be used to filter the retrieved events by the following criteria.</p>
+
+        <h3 id="local-ongoing">Ongoing local events</h3>
+        <p>Use to quickly access local (municipality level) events that are upcoming or have not ended yet. Combines the search on a number of description, name, and keyword fields. Locality is defined onthe basis of MUNIGEO_MUNI value, which is set in the settings file. In the Helsinki case all the events would be retrieved that happen within Helsinki. Comes in two flavors: AND and OR. 
+        Use <code>local_ongoing_AND=lapset,musiikki</code> to search for the events with both search terms in the description fields and <code>local_ongoing_OR</code> to search for the events with atleast one term mentioned. In case you need to realize a more complicated logic and search for a combination of search terms as in <code>(singing OR vocal) AND (workshop OR training)</code> use <code>local_ongoing_OR_setX</code> parameter, where <code>X</code> is a number.</p>
+        <p>Examples:</p>
+        <pre><code>event/?local_ongoing_OR=lapsi,musiikki</code></pre>
+        <pre><code>event/?local_ongoing_OR_set1=lapsi,musiikki&local_ongoing_OR_set2=leiri,kurssi</code></pre>
+
+        <h3 id="internet-ongoing">Ongoing internet events</h3>
+        <p>Use to quickly access internet-based events that are upcoming or have not ended yet. Usage is thesame as for local ongoing events, three variations: <code>internet_ongoing_AND</code>, <code>internet_ongoing_OR</code>, and <code>internet_ongoing_OR_setX</code>, Note, that <code>local_ongoing</code> and <code>internet_ongoing</code> are mutually exclusive.</p>
+        <p>Example:</p>
+        <pre><code>event/?internet_ongoing_AND=lapsi,musiikki</code></pre>
+
+        <h3 id="all-ongoing">All ongoing events</h3>
+        <p>All ongoing events, both internet and local combined. Usage is the same as for local ongoing events: <code>all_ongoing_AND</code>, <code>all_ongoing_OR</code> and <code>all_ongoing_OR_setX</code></p>
+        <p>Example:</p>
+        <pre><code>event/?all_ongoing_AND=lapsi,musiikki</code></pre>
+
+        <h3 id="internet-based">Internet based</h3>
+        <p>Filter for all the events that happen in the internet, both past and upcoming.</p>
+        <p>Example:</p>
+        <pre><code>event/?internet_based=true</code></pre>
+
         <h3 id="event-time">Event time</h3>
-        <p>Use <code>start</code> and <code>end</code> to restrict the date range of returned events.
-        Any events that intersect with the given date range will be returned.</p>
+        <p>Use <code>start</code> and <code>end</code> to restrict the date range of returned events. Any events that intersect with the given date range will be returned.</p>
         <p>The parameters <code>start</code> and <code>end</code> can be given in the following formats:</p>
         <ul>
-        <li>ISO 8601 (including the time of day), i.e. YYYY-MM-DDTHH:MM:SSZ</li>
-        <li>yyyy-mm-dd</li>
+            <li>ISO 8601 (including the time of day), i.e. YYYY-MM-DDTHH:MM:SSZ</li>
+            <li>yyyy-mm-dd</li>
         </ul>
-        <p>In addition, <code>today</code> (for start or end of today) and <code>now</code>
-        (for the exact current timestamp) can be used in either parameter to get current events.</p>
+        <p>In addition, <code>today</code> (for start or end of today) and <code>now</code> (for the exact current timestamp) can be used in either parameter to get current events.</p>
         <p>Example:</p>
-        <pre><code>event/?start=today&amp;end=2020-12-31
-        </code></pre>
-        <p><a href="?start=today&amp;end=2020-12-31" title="json">See the result</a></p>
-        <pre><code>event/?start=now&amp;end=today
-        </code></pre>
-        <p><a href="?start=now&amp;end=today" title="json">See the result</a></p>
+        <pre><code>event/?start=today&amp;end=2020-12-31</code></pre>
+        <pre><code>event/?start=now&amp;end=today</code></pre>
+
+        <p>You can also use <code>days</code> filter to restrict the date range of returned events. Any events that intersect with the current time and amount of days from current time will be returned.</p>
+        <p>The parameters <code>start</code> and <code>end</code> cannot be used together with the <code>days</code> parameter.</p>
+        <p>Example:</p>
+        <pre><code>event/?days=7</code></pre>
+
+        <h3 id="event-hours">Event start/end time</h3>
+        <p>Use <code>starts_after</code>, <code>starts_before</code>, <code>ends_after</code>, and<code>ends_before</code> to filter for the events that start and end within certain hours, for example for the ones that start after 17:00 and end before 21:00.</p>
+        <p>The parameters can be given as:</p>
+        <ul>
+            <li>Hours only</li>
+            <li>Hours and minutes separated by a colon</li>
+        </ul>
+        <p>Example:</p>
+        <pre><code>event/?starts_after=16:30&amp;ends_before=21</code></pre>
+
+        <h3 id="event-duration">Event duration</h3>
+        <p>Use <code>max_duration</code> to filter for the events that last up to a specified time, or <code>min_duration</code> to filter for the events that last at least a specified amount of time.</p>
+        <p>The parameters are expressed in format:</p>
+        <ul>
+            <li>86400 or 86400s (24 hours)</li>
+            <li>180m or 3h (3 hours)</li>
+            <li>3d (3 days)</li>
+        </ul>
+        <p>Example:</p>
+        <pre><code>event/?max_duration=3d</code></pre>
+
         <h3 id="event-location">Event location</h3>
         <h4 id="bounding-box">Bounding box</h4>
-        <p>To restrict the retrieved events to a geographical region, use
-        the query parameter <code>bbox</code> in the format</p>
-        <pre><code>bbox=west,south,east,north
-        </code></pre>
-        <p>Where <code>west</code> is the longitude of the rectangle's western boundary,
-        <code>south</code> is the latitude of the rectangle's southern boundary,
-        and so on. The coordinate system is the trusty old EPSG:4326 known from all online maps.</p>
+        <p>To restrict the retrieved events to a geographical region, use the query parameter <code>bbox</code> in the format</p>
+        <pre><code>bbox=west,south,east,north</code></pre>
+        <p>Where <code>west</code> is the longitude of the rectangle's western boundary, <code>south</code> is the latitude of the rectangle's southern boundary, and so on. The default coordinate systemis the trusty old EPSG:4326 known from all online maps, and can be overridden with <code>srid</code> parameter.</p>
         <p>Example:</p>
-        <pre><code>event/?bbox=24.9348,60.1762,24.9681,60.1889
-        </code></pre>
-        <p><a href="?bbox=24.9348,60.1762,24.9681,60.1889" title="json">See the result</a></p>
+        <pre><code>event/?bbox=24.9348,60.1762,24.9681,60.1889</code></pre>
+
         <h4 id="specific-location">Specific location</h4>
-        <p>To restrict the retrieved events to a known location(s), use
-        the query parameter <code>location</code>, separating values by commas
-        if you wish to query for several locations.</p>
-        <p>Location ids are found at the <code>place</code> endpoint, which lists the
-        locations in decreasing number of events found. Most locations
-        originate from the Helsinki service point registry (tprek), hence
-        the format <code>tprek:28473</code>. An easy way to locate service points is
-        to browse <code>servicemap.hel.fi</code>, which uses the same location ids,
-        e.g. <code>servicemap.hel.fi/unit/28473</code>.</p>
+        <p>To restrict the retrieved events to a known location(s), use the query parameter <code>location</code>, separating values by commas if you wish to query for several locations.</p>
+        <p>Location ids are found at the <code>place</code> endpoint, which lists the locations in decreasing number of events found. Most locations originate from the Helsinki service point registry (tprek), hence the format <code>tprek:28473</code>. An easy way to locate service points is to browse <code>servicemap.hel.fi</code>, which uses the same location ids, e.g. <code>servicemap.hel.fi/unit/28473</code>.</p>
         <p>Example:</p>
-        <pre><code>event/?location=tprek:28473
-        </code></pre>
-        <p><a href="?location=tprek:28473" title="json">See the result</a></p>
+        <pre><code>event/?location=tprek:28473</code></pre>
+
         <h4 id="district">District</h4>
-        <p>To restrict the retrieved events to city district(s), use the
-        query parameter <code>division</code>, separating values by commas
-        if you wish to query for several divisions.</p>
-        <p>City of Helsinki neighborhoods (kaupunginosa), districts (peruspiiri)
-        and subdistricts (osa-alue) are supported.
-            <a href="https://kartta.hel.fi/link/8BqeiY">
-                Check the divisions on the Helsinki map service.</a>
-        </p>
-        <p> You may query either by specific OCD division type <code>peruspiiri:malmi</code>, or by division name
-        <code>malmi</code>. The latter query checks all divisions with the name,
-        regardless of division type.</p>
+        <p>To restrict the retrieved events to city district(s), use the query parameter <code>division</code>, separating values by commas if you wish to query for several divisions.</p>
+        <p>City of Helsinki neighborhoods (kaupunginosa), districts (peruspiiri) and subdistricts (osa-alue) are supported. <a href="https://kartta.hel.fi/link/8BqeiY">Check the divisions on the Helsinki map service.</a></p>
+        <p> You may query either by specific OCD division type <code>peruspiiri:malmi</code>, or by division name <code>malmi</code>. The latter query checks all divisions with the name, regardless of division type.</p>
         <p>Example:</p>
-        <pre><code>event/?division=malmi
-        </code></pre>
-        <p><a href="?division=malmi" title="json">See the result</a></p>
+        <pre><code>event/?division=malmi</code></pre>
+
+        <h4 id="distance-filter">Within a distance (or "circle filter")</h4>
+        <p>To restrict the retrieved events to a certain distance from a point, use the query parameters <code>dwithin_origin</code> and <code>dwithin_metres</code> in the format</p>
+        <pre><code>dwithin_origin=lon,lat&dwithin_metres=distance</code></pre>
+        <p>Where <code>lon</code> is the longitude of the origin point, <code>lat</code> is the latitude of the origin point, and <code>distance</code> is the radius in metres. Both parameters are required. The default coordinate system is EPSG:4326 and can be overridden with the <code>srid</code> parameter.</p>
+        <p>Example:</p>
+        <pre><code>event/?dwithin_origin=24.9348,60.1762&dwithin_metres=1000</code></pre>
+
+
         <h3 id="event-category">Event category</h3>
-        <p>To restrict the retrieved events by category, use the query
-        parameter <code>keyword</code>, separating values by commas if you wish to
-        query for any of several keywords, or the parameter <code>keyword_AND</code>, if you require all
-        provided values (separated by commas) to be present.</p>
-        <p>Keyword ids are found at the <code>keyword</code> endpoint, which lists the
-        keywords in decreasing number of events found. The common keywords
-        used in all events originate from the general Finnish ontology (YSO),
-        hence the format <code>yso:p4354</code>.</p>
-        <p>The most common event categories are listed in the two keyword sets
-            <a href="https://api.hel.fi/linkedevents/v1/keyword_set/helsinki:topics/">helsinki:topics</a> and
-            <a href="https://api.hel.fi/linkedevents/v1/keyword_set/helsinki:audiences/">helsinki:audiences</a>,
-        which list the YSO keywords that are present in most events to specify event main topic and audience.</p>
+        <p>To restrict the retrieved events by category, use the query parameter <code>keyword</code>, separating values by commas if you wish to query for any of several keywords, or the parameter <code>keyword_AND</code>, if you require all provided values (separated by commas) to be present. Use parameter <code>keyword!</code> if you require all provided values (separated by commas)<strong>not</strong> to be present.</p>
+        <p>In case you need to realize a more complicated logic and search for a  combination of keywords as in <code>(yso:p1235 OR yso:p1947) AND (yso:p14004 OR yso:p11185)</code> use <code>keyword_OR_setX</code> parameter, where <code>X</code> is a number.</p>
+        <p>Keyword ids are found at the <code>keyword</code> endpoint, which lists the keywords in decreasing number of events found. The common keywords used in all events originate from the general Finnish ontology (YSO), hence the format <code>yso:p4354</code>.</p>
+        <p>The most common event categories are listed in the two keyword sets <a href="https://api.hel.fi/linkedevents/v1/keyword_set/helsinki:topics/">helsinki:topics</a> and <a href="https://api.hel.fi/linkedevents/v1/keyword_set/helsinki:audiences/">helsinki:audiences</a>, which list the YSO keywords that are present in most events to specify event main topic and audience.</p>
         <p>Example:</p>
-        <pre><code>event/?keyword=yso:p4354
-        </code></pre>
-        <p><a href="?keyword=yso:p4354" title="json">See the result</a></p>
+        <pre><code>event/?keyword=yso:p4354</code></pre>
+        <pre><code>event/?keyword_OR_set1=yso:p1235,yso:p1947&keyword_OR_set2=yso:p14004,yso:p11185</code></pre>
+
+        <h3 id="event-category">Keyword set search</h3>
+        <p>Some services maintain curated keyword sets, which can also be used in search with query parameters <code>keyword_set_AND</code> and <code>keyword_set_OR</code>. As names of the keyword sets can repeat between the services, ids should be supplied. Say, we have one keyword set <b>Music</b> with id "myservice:1" that contains keywords rock and jazz, and another keyword set<b>Workshops</b> with keywords "workshop" and "seminar" and id "myservice:2". Then a request <code>/event/?keyword_set_AND=myservice:1,myservice:2</code> would return the events matching the following expression: (rock OR jazz) AND (workshop OR seminar).</p>
+
         <h3 id="event-last-modified">Event last modification time</h3>
-        <p>To find events that have changed since you last polled Linkedevents API (to e.g. update your event cache),
-        it is best to use the query parameter <code>last_modified_since</code>. This allows you to only return data
-        that has changed after your last update. You may also include events that have been deleted in the API in
-        the results by using the <code>show_deleted</code> filter. This allows you to update your cache with all added,
-        modified and deleted events without having to fetch *all* future events every time.</p>
-        </p>
-        </p>
+        <p>To find events that have changed since you last polled Linkedevents API (to e.g. update your event cache), it is best to use the query parameter <code>last_modified_since</code>. This allows you to only return data that has changed after your last update. You may also include events that have been deleted in the API in the results by using the <code>show_deleted</code> filter. This allows you to update your cache with all added, modified and deleted events without having to fetch *all* future events every time.</p>
         <p>Example:</p>
-        <pre><code>event/?last_modified_since=2020-04-07&show_deleted=True
-        </code></pre>
-        <p><a href="?last_modified_since=2020-04-07&show_deleted=True" title="json">See the result</a></p>
+        <pre><code>event/?last_modified_since=2020-04-07&show_deleted=True</code></pre>
+
+        <h3 id="event-ids">Specific ids</h3>
+        <p>To find events that have specific id use parameter <code>ids</code>, separating values by commas if you wish to query for several event ids.</p>
+        <p>Example:</p>
+        <pre><code>event/?ids=helsinki:1</code></pre>
+
         <h3 id="event-status">Event status</h3>
-        <p>Events in Linkedevents (indicated by the <code>event_status</code> field) may be either scheduled as planned
-        (<code>EventScheduled</code>), rescheduled if their start time has changed after they were first published
-        (<code>EventRescheduled</code>), cancelled if they were cancelled altogether after publication
-        (<code>EventCancelled</code>), or postponed to the indefinite future if they could not be organized at the
-        original time (<code>EventPostponed</code>). These statuses stem from <a href='https://schema.org/eventStatus'>
-        schema.org</a>.</p>
+        <p>Events in Linkedevents (indicated by the <code>event_status</code> field) may be either scheduled as planned (<code>EventScheduled</code>), rescheduled if their start time has changed after they were first published (<code>EventRescheduled</code>), cancelled if they were cancelled altogether after publication (<code>EventCancelled</code>), or postponed to the indefinite future if they could not be organized at the original time (<code>EventPostponed</code>). These statuses stem from <a href='https://schema.org/eventStatus'>schema.org</a>.</p>
         <p>You may filter events with only the desired status with the <code>event_status</code> filter.</p>
         <p>Example:</p>
-        <pre><code>event/?event_status=EventCancelled
-        </code></pre>
-        <p><a href="?event_status=EventCancelled" title="json">See the result</a></p>
+        <pre><code>event/?event_status=EventCancelled</code></pre>
+
+        <p>It is also possible to use multiple <code>event_status</code> parameters in a single query.
+            Statuses must be separated by a comma.</p>
+        <p>Example:</p>
+        <pre><code>event/?event_status=EventCancelled,EventPostponed</code></pre>
+
+        <h3 id="event-type">Event type</h3>
+        <p>Events in Linkedevents (indicated by the <code>type_id</code> field) may be event (<code>General</code>), course (<code>Course</code>) or volunteering (<code>Volunteering</code>). By default, only events with General type_id are returned.</p>
+        <p>You may filter events with only the desired type with the <code>event_type</code> filter, separating values by commas if you wish to query for several types.</p>
+        <p>Example:</p>
+        <pre><code>event/?event_type=General,Course</code></pre>
+
         <h3 id="event-text">Event text</h3>
-        <p>To find out events that contain a specific string in any of the text
-        fields, use the query parameter <code>text</code>.</p>
+        <p>To find out events that contain a specific string in any of the text fields, use the query parameter <code>text</code>.</p>
         <p>Example:</p>
-        <pre><code>event/?text=shostakovich
-        </code></pre>
-        <p><a href="?text=shostakovich" title="json">See the result</a></p>
+        <pre><code>event/?text=shostakovich</code></pre>
+
+        <h3 id="event-combined_text">Combined text</h3>
+        <p>While the <code>text</code> search is looking for the events containg exact matches of the search string, <code>combined_text</code> filtering finds events with exact text match for event text fields but retrieves expected keywords on the basis of similarity.</p>
+        <p>Example:</p>
+        <pre><code>event/?combined_text=lapppset</code></pre>
+
         <h3 id="event-price">Event price</h3>
-        <p>Events may or may not contain the <code>offers</code> field that lists event pricing. To return only
-        free or non-free events, use the query parameter<code>is_free</code>. However, note that from some
-        data sources, no event pricing info is available, so this filter will only return those events which
-        have pricing data available.</p>
+        <p>Events may or may not contain the <code>offers</code> field that lists event pricing. To return only free or non-free events, use the query parameter<code>is_free</code>. However, note that from some data sources, no event pricing info is available, so this filter will only return those events which have pricing data available.</p>
         <p>Example:</p>
-        <pre><code>event/?is_free=true
-        </code></pre>
-        <p><a href="?is_free=true" title="json">See the result</a></p>
+        <pre><code>event/?is_free=true</code></pre>
+
         <h3 id="event-language">Event language</h3>
-        <p>To find events that have a set language or event data translated into
-        that language, use the query parameter <code>language</code>. If you only wish to see
-        events that have a set language, use the <code>in_language</code> parameter, and if
-        you only want event data translated to a set language, use the <code>translation</code> parameter.</p>
-        <p>Supported languages are found at the <code>language</code> endpoint, which also lists
-        which languages have translations available. Currently, translations are supported
-        in <code>fi</code>, <code>sv</code>, <code>en</code>, <code>ru</code>,
-        <code>zh_hans</code>, and <code>ar</code>.</p>
+        <p>To find events that have a set language or event data translated into that language, use the query parameter <code>language</code>. If you only wish to see events that have a set language, use the <code>in_language</code> parameter, and if you only want event data translated to a set language, use the <code>translation</code> parameter.</p>
+        <p>Supported languages are found at the <code>language</code> endpoint, which also lists which languages have translations available. Currently, translations are supported in <code>fi</code>, <code>sv</code>, <code>en</code>, <code>ru</code>, <code>zh_hans</code>, and <code>ar</code>.</p>
         <p>Example:</p>
-        <pre><code>event/?language=ru
-        </code></pre>
-        <p><a href="?language=ru" title="json">See the result</a></p>
+        <pre><code>event/?language=ru</code></pre>
+
+        <h3 id="audience-age">Event audience age boundaries.</h3>
+        <p>To find events that are designed for specific age audiences use the query paramteres <code>audience_min_age_lt</code>, <code>audience_min_age_gt</code>, <code>audience_max_age_lt</code>, <code>audience_max_age_gt</code>.</p>
+        <p> <code>audience_min_age_lt</code> returns the events whose minimal age is lower than or equals the specified value, <code>audience_min_age_gt</code> returns the events whose minimal age is greater than or equals the specified value. <code>max_age</code> parameteres, naturally, work the same way only for the maximum age of the event audience. Note, that the events that are not designed for 
+            the specific audiences will be omitted.</p>
+        <p><code>audience_max_age</code> and <code>audience_min_age</code> parameters without <code>lt</code> and <code>gt</code> modifiers are left for backward compatibility only and should not be employed.</p>
+        <p>Example:</p>
+        <pre><code>event/?audience_min_age_gt=10</code></pre>
+
+        <h3 id="suitable_for">Select events suitable for certain age.</h3>
+        <p>To find events that are suitable for certain age  use the query paramter <code>suitable_for</code> that returns all the events that are suitable for the age or age range specified. Under the hood it excludes all the events that have max age limit below or min age limit above the age specified. Suitable events with just one age boundary specified are returned, events with no age limits specified are excluded. Query parameter can take either one or two arguments, the order of parameters when specifying the age range is not important.</p>
+        <p>Examples:</p>
+        <pre><code>event/?suitable_for=12</code></pre>
+        <pre><code>event/?suitable_for=12,14</code></pre>
+
         <h3 id="event-publisher">Event publisher</h3>
-        <p>To find out events that are published by a specific organization, use the query
-        parameter <code>publisher</code>, separating values by commas if you wish to query for several publishers.</p>
-        <p>Existing publisher organizations are found at the <code>organization</code> endpoint. City of Helsinki
-        internal publishers have ids of the form <code>ahjo:origin_id</code> as they originate from
-        the Helsinki Ahjo decisionmaking system, and have a rather complex hierarchy. External publishers may have
-        their own namespaces, ids and hierarchies.</p>
-        <p>Also, it is possible to fetch events under a specific publisher organization hierarchy (say
-        <a href='https://api.hel.fi/linkedevents/v1/organization/ahjo:00001/'>City of Helsinki</a>) by using the
-        parameter <code>publisher_ancestor</code>, which returns all events published by any suborganizations
-        (at any level) of the given organization.</p>
+        <p>To find out events that are published by a specific organization, use the query parameter <code>publisher</code>, separating values by commas if you wish to query for several publishers.</p>
+        <p>Existing publisher organizations are found at the <code>organization</code> endpoint. City of Helsinki internal publishers have ids of the form <code>ahjo:origin_id</code> as they originate from the Helsinki Ahjo decisionmaking system, and have a rather complex hierarchy. External publishers may have their own namespaces, ids and hierarchies.</p>
+        <p>Also, it is possible to fetch events under a specific publisher organization hierarchy (say <a href='https://api.hel.fi/linkedevents/v1/organization/ahjo:00001/'>City of Helsinki</a>) by using the parameter <code>publisher_ancestor</code>, which returns all events published by any suborganizations (at any level) of the given organization.</p>
         <p>Example:</p>
-        <pre><code>event/?publisher=ytj:0586977-6
-        </code></pre>
-        <p><a href="?publisher=ytj:0586977-6" title="json">See the result</a></p>
-        <pre><code>event/?publisher_ancestor=ahjo:00001
-        </code></pre>
-        <p><a href="?publisher_ancestor=ahjo:00001" title="json">See the result</a></p>
+        <pre><code>event/?publisher=ytj:0586977-6</code></pre>
+        <pre><code>event/?publisher_ancestor=ahjo:00001</code></pre>
+
         <h3 id="event-data-source">Event data source</h3>
-        <p>To find out events that originate from a specific source system, use the query parameter
-        <code>data_source</code>. All event ids are of the form <code>data_source:origin_id</code>, so this allows
-        you to return only events coming to Linkedevents from a specific data system. <code>helsinki</code> is the
-        name of our own data source, i.e. events where Linkedevents API itself is the master data.</p>
+        <p>To find out events that originate from a specific source system, use the query parameter <code>data_source</code>. All event ids are of the form <code>data_source:origin_id</code>, so this allows you to return only events coming to Linkedevents from a specific data system. <code>helsinki</code> is the name of our own data source, i.e. events where Linkedevents API  itself is the master data.</p>
         <p>Example:</p>
-        <pre><code>event/?data_source=helmet
-        </code></pre>
-        <p><a href="?data_source=helmet" title="json">See the result</a></p>
+        <pre><code>event/?data_source=helmet</code></pre>
+
         <h3 id="event-hierarchy">Event hierarchy</h3>
-        <p>Events in linkedevents may be either standalone events, or they may have super or sub
-        events. There are two types of super events, indicated in the field
-        <code>super_event_type</code> by <code>recurring</code> (repeating events, event series)
-        and <code>umbrella</code> (festivals etc.).</p>
-        <p><code>recurring</code> events last for a period and have <code>sub_events</code> that all
-        have similar data, but different dates.</p>
-        <p><code>umbrella</code> events last for a period and may have different
-        <code>sub_events</code>, including <code>recurring</code> events (i.e. an
-        <code>umbrella</code> festival may have a <code>recurring</code> theater play
-        <code>sub_event</code>, which may have several nights as <code>sub_events</code>.)</p>
+        <p>Events in linkedevents may be either standalone events, or they may have super or sub events. There are two types of super events, indicated in the field <code>super_event_type</code> by <code>recurring</code> (repeating events, event series) and <code>umbrella</code> (festivals etc.).</p>
+        <p><code>recurring</code> events last for a period and have <code>sub_events</code> that all have similar data, but different dates.</p>
+        <p><code>umbrella</code> events last for a period and may have different <code>sub_events</code>, including <code>recurring</code> events (i.e. an <code>umbrella</code> festival may have a <code>recurring</code> theater play <code>sub_event</code>, which may have several nights as <code>sub_events</code>.)</p>
+
         <h4 id="super-event-type">Super event type</h4>
-        <p>You may use the query parameter <code>super_event_type</code>, comma separated, to get
-        only super events of specific types. You may use <code>none</code> if you want non-super
-        events included.</p>
+        <p>You may use the query parameter <code>super_event_type</code>, comma separated, to get only super events of specific types. You may use <code>none</code> if you want non-super events included.</p>
         <p>Example:</p>
-        <pre><code>event/?super_event_type=umbrella,none
-        </code></pre>
-        <p><a href="?super_event_type=umbrella,none" title="json">See the result</a></p>
+        <pre><code>event/?super_event_type=umbrella,none</code></pre>
+
         <h4 id="super-event-type">Super event</h4>
-        <p>You may use the query parameter <code>super_event</code>, comma separated, to get all
-        subevents for specific superevents. You may use <code>none</code> if you want all
-        events which have no superevent included.</p>
+        <p>You may use the query parameter <code>super_event</code>, comma separated, to get all subevents for specific superevents. You may use <code>none</code> if you want all events which have no superevent included.</p>
         <p>Example:</p>
-        <pre><code>event/?super_event=linkedevents:agg-103
-        </code></pre>
-        <p><a href="?super_event=linkedevents:agg-103" title="json">See the result</a></p>
+        <pre><code>event/?super_event=linkedevents:agg-103</code></pre>
+
+        <h3 id="event-registration">Event with registration</h3>
+        <p>To find out events with or without a registration, use the query parameter<code>registration</code>.</p>
+        <p>Example:</p>
+        <pre><code>event/?registration=true</code></pre>
+
+        <h3 id="enrolment">Open enrolment</h3>
+        <p>Two endpoints show the events that have connected registrations and have places either at the event itself <code>enrolment_open</code> or in the waiting lists <code>enrolment_open_waitlist</code>. Note that the latter query parameter when set to <code>True</code> returns also the events that have open spots at the event itself. Null values are regarded as unlimited number of spots at the event or in the waiting list.</p>
+        <p>For example:</p>
+        <pre><code>event/?enrolment_open_waitilist=true</code></pre>
+
+        <h3 id="event-for-authenticated-users">Filtering for authenticated users</h3>
+        <p>By default, only public events are shown in the event list. However, certain query parameters allow customizing the listing for authenticated users</p>
+
+        <h4 id="event-show-all">Show all events</h4>
+        <p><code>show_all</code> parameter displays all events authenticated user can edit, including drafts, and public non-editable events</p>
+        <p>Example:</p>
+        <pre><code>event/?show_all=true</code></pre>
+
+        <h4 id="event-publication-status">Publication status</h4>
+        <p>Events in Linkedevents (indicated by the <code>publication_status</code> field) may be either(<code>draft</code>) if the event is not published yet or (<code>public</code>) for published events.</p>
+        <p>You may filter events with only the desired publication status with the <code>publication_status</code> filter.</p>
+        <p>Example:</p>
+        <pre><code>event/?publication_status=draft</code></pre>
+
+        <h4 id="event-editable-events">Only editable events</h4>
+        <p><code>admin_user</code> parameter displays all events authenticated user can edit, including drafts, but no other  public events</p>
+        <p>Example:</p>
+        <pre><code>event/?admin_user=true</code></pre>
+
+        <h4 id="event-created-by">Events created by the user</h4>
+        <p><code>created_by</code> parameter only displays events by the authenticated user</p>
+        <p>Example:</p>
+        <pre><code>event/?created_by=true</code></pre>
+
         <h2 id="getting-detailed-data">Getting detailed data</h2>
-        <p>In the default case, keywords, locations, and other fields that
-        refer to separate resources are only displayed as simple references.</p>
-        <p>If you want to include the complete data from related resources in
-        the current response, use the keyword <code>include</code>. <strong> Please note, however,
-        that including all the resources inlined in *every* event will result in a huge number
-        of duplicate data in the json, making the json very slow to generate and process and causing
-        considerable API load and long response times when too many such requests are made. Therefore,
-        if you are listing the maximum number of events (100) or updating your cache with all events,
-        please consider caching the keyword and location data separately to prevent unnecessary API
-        slowdown and continuous repeated work. Keyword and location data seldom change and are easily
-        fetched from their own endpoints separately.
-        </strong></p>
+        <p>In the default case, keywords, locations, and other fields that refer to separate resources are only displayed as simple references.</p>
+        <p>If you want to include the complete data from related resources in the current response, use the keyword <code>include</code>. <strong> Please note, however, that including all the resources inlined in *every* event will result in a huge number of duplicate data in the json, making the json very slow to generate and process and causing considerable API load and long response times when too many such requests are made. Therefore, if you are listing the maximum number of events (100) or updating your cache with all events, please consider caching the keyword and location data separately to prevent unnecessary API slowdown and continuous repeated work. Keyword and location data seldom change and are easily fetched from their own endpoints separately.</strong></p>
         <p>Example:</p>
-        <pre><code>event/?include=location,keywords
-        </code></pre>
-        <p><a href="?include=location,keywords" title="json">See the result</a></p>
+        <pre><code>event/?include=location,keywords</code></pre>
+
         <h2 id="ordering">Ordering</h2>
-        <p>Default ordering is descending order by <code>-last_modified_time</code>.
-        You may also order results by <code>start_time</code>, <code>end_time</code>,
-        <code>name</code> and <code>duration</code>. Descending order is denoted by
-        adding <code>-</code> in front of the parameter, default order is ascending.
-        For example:</p>
-        <pre><code>event/?sort=-end_time
-        </code></pre>
-        <p><a href="?sort=-end_time" title="json">See the result</a></p>
+        <p>Default ordering is descending order by <code>-last_modified_time</code>. You may also order  results by <code>start_time</code>, <code>end_time</code>, <code>name</code> and <code>duration</code>. Descending order is denoted by adding <code>-</code> in front of the parameter, default order is ascending.</p>
+        <p>For example:</p>
+        <pre><code>event/?sort=-end_time</code></pre>
       operationId: Event_list
-      tags:
-      - event
+      parameters:
+        - $ref: "#/components/parameters/page_param"
+        - $ref: "#/components/parameters/pagesize_param"
+        - $ref: "#/components/parameters/event_local_ongoing_AND_param"
+        - $ref: "#/components/parameters/event_local_ongoing_OR_param"
+        - $ref: "#/components/parameters/event_internet_ongoing_AND_param"
+        - $ref: "#/components/parameters/event_internet_ongoing_OR_param"
+        - $ref: "#/components/parameters/event_all_ongoing_AND_param"
+        - $ref: "#/components/parameters/event_all_ongoing_OR_param"
+        - $ref: "#/components/parameters/event_internet_based_param"
+        - $ref: "#/components/parameters/event_start_param"
+        - $ref: "#/components/parameters/event_end_param"
+        - $ref: "#/components/parameters/event_days_param"
+        - $ref: "#/components/parameters/event_starts_after_param"
+        - $ref: "#/components/parameters/event_starts_before_param"
+        - $ref: "#/components/parameters/event_ends_after_param"
+        - $ref: "#/components/parameters/event_ends_before_param"
+        - $ref: "#/components/parameters/event_min_duration_param"
+        - $ref: "#/components/parameters/event_max_duration_param"
+        - $ref: "#/components/parameters/event_bbox_param"
+        - $ref: "#/components/parameters/event_location_param"
+        - $ref: "#/components/parameters/event_division_param"
+        - $ref: "#/components/parameters/event_dwithin_origin_param"
+        - $ref: "#/components/parameters/event_dwithin_metres_param"
+        - $ref: "#/components/parameters/event_keyword_param"
+        - $ref: "#/components/parameters/event_keyword_AND_param"
+        - $ref: "#/components/parameters/event_keyword_NOT_param"
+        - $ref: "#/components/parameters/event_keyword_set_AND_param"
+        - $ref: "#/components/parameters/event_keyword_set_OR_param"
+        - $ref: "#/components/parameters/event_last_modified_param"
+        - $ref: "#/components/parameters/event_show_deleted_param"
+        - $ref: "#/components/parameters/event_ids_param"
+        - $ref: "#/components/parameters/event_event_status_param"
+        - $ref: "#/components/parameters/event_event_type_param"
+        - $ref: "#/components/parameters/event_text_param"
+        - $ref: "#/components/parameters/event_combined_text_param"
+        - $ref: "#/components/parameters/event_is_free_param"
+        - $ref: "#/components/parameters/event_language_param"
+        - $ref: "#/components/parameters/event_in_language_param"
+        - $ref: "#/components/parameters/event_translation_param"
+        - $ref: "#/components/parameters/event_audience_min_age_lt_param"
+        - $ref: "#/components/parameters/event_audience_min_age_gt_param"
+        - $ref: "#/components/parameters/event_audience_max_age_lt_param"
+        - $ref: "#/components/parameters/event_audience_max_age_gt_param"
+        - $ref: "#/components/parameters/event_suitable_for_param"
+        - $ref: "#/components/parameters/event_publisher_param"
+        - $ref: "#/components/parameters/event_publisher_ancestor_param"
+        - $ref: "#/components/parameters/event_data_source_param"
+        - $ref: "#/components/parameters/event_super_event_type_param"
+        - $ref: "#/components/parameters/event_super_event_param"
+        - $ref: "#/components/parameters/event_registration_param"
+        - $ref: "#/components/parameters/event_enrolment_open_param"
+        - $ref: "#/components/parameters/event_enrolment_open_waitlist_param"
+        - $ref: "#/components/parameters/event_show_all_param"
+        - $ref: "#/components/parameters/event_publication_status_param"
+        - $ref: "#/components/parameters/event_admin_user_param"
+        - $ref: "#/components/parameters/event_created_by_param"
+        - $ref: "#/components/parameters/include_param"
+        - $ref: "#/components/parameters/event_sort_param"
       responses:
         200:
           description: List of events
-          schema:
-            type: object
-            properties:
-              meta:
-                $ref: '#/definitions/meta_definition'
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/event'
-      parameters:
-      - $ref: '#/parameters/page_param'
-      - $ref: '#/parameters/pagesize_param'
-      - $ref: '#/parameters/include_param'
-      - $ref: '#/parameters/event_text_param'
-      - $ref: '#/parameters/event_last_modified_param'
-      - $ref: '#/parameters/event_show_deleted_param'
-      - $ref: '#/parameters/event_event_status_param'
-      - $ref: '#/parameters/event_is_free_param'
-      - $ref: '#/parameters/event_start_param'
-      - $ref: '#/parameters/event_end_param'
-      - $ref: '#/parameters/event_bbox_param'
-      - $ref: '#/parameters/event_data_source_param'
-      - $ref: '#/parameters/event_location_param'
-      - $ref: '#/parameters/event_division_param'
-      - $ref: '#/parameters/event_keyword_param'
-      - $ref: '#/parameters/event_keyword_AND_param'
-      - $ref: '#/parameters/event_min_duration_param'
-      - $ref: '#/parameters/event_max_duration_param'
-      - $ref: '#/parameters/event_language_param'
-      - $ref: '#/parameters/event_translation_param'
-      - $ref: '#/parameters/event_in_language_param'
-      - $ref: '#/parameters/event_publisher_param'
-      - $ref: '#/parameters/event_publisher_ancestor_param'
-      - $ref: '#/parameters/event_super_event_type_param'
-      - $ref: '#/parameters/event_super_event_param'
-      - $ref: '#/parameters/event_sort_param'
-
-    post:
-      summary: Create a new event or events
-      operationId: event_create
-      tags:
-      - event
-      responses:
-        201:
-          description: Object(s) has/have been succesfully created. A copy of the object(s) is returned in response body and headers contain Location pointing to the created event
-          schema:
-            $ref: '#/definitions/event'
-        400:
-          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed
-        401:
-          description: User was not authenticated
-        403:
-          description: User does not have necessary permissions
-      parameters:
-      - name: event_object
-        in: body
-        schema:
-          $ref: '#/definitions/event'
-      - name: event_objects
-        in: body
-        schema:
-          type: array
-          items:
-            $ref: '#/definitions/event'
-
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  meta:
+                    $ref: "#/components/schemas/meta_definition"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/event"
     put:
-      summary: Bulk update several events
-      description: Events can be updated if the user has appropriate access permissions. The original implementation behaves like PATCH, ie. if some field is left out from the PUT call, its value is retained in database. In order to ensure consistent behaviour, users should always supply every field in PUT call.
-      operationId: event_bulk_update
       tags:
-      - event
+        - event
+      summary: Bulk update several events
+      description:
+        Events can be updated if the user has appropriate access permissions.
+        The original implementation behaves like PATCH, ie. if some field is left out from the PUT call, its value is retained in database. In order to ensure consistent behaviour, users should always supply every field in PUT call.
+      operationId: event_bulk_update
+      requestBody:
+        description: Event objects that should replace the existing events. Each object must have id field that refers to an existing event.
+        content:
+          "*/*":
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/event"
+        required: false
       responses:
         200:
-          description: Events have been successfully updated
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/event'
+          description: Events have been successfully updated.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/event"
         400:
-          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed
+          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed.
+          content: {}
         401:
-          description: User was not authenticated
+          description: User was not authenticated.
+          content: {}
         403:
-          description: User does not have necessary permissions for all referred events
-      parameters:
-      - name: event_objects
-        in: body
-        description: Event objects that should replace the existing events. Each object must have id field that refers to an existing event.
-        schema:
-          type: array
-          items:
-            $ref: '#/definitions/event'
-
+          description: User does not have necessary permissions for all referred events.
+          content: {}
+      x-codegen-request-body-name: event_objects
+    post:
+      tags:
+        - event
+      summary: Create a new event or events
+      operationId: event_create
+      requestBody:
+        content:
+          "*/*":
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/event"
+        required: false
+      responses:
+        201:
+          description: Object(s) has/have been succesfully created. A copy of the object(s) is returned in response body and headers contain Location pointing to the created event.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/event"
+        400:
+          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed.
+          content: {}
+        401:
+          description: User was not authenticated.
+          content: {}
+        403:
+          description: User does not have necessary permissions.
+          content: {}
+      x-codegen-request-body-name: event_objects
   /event/{id}/:
     get:
+      tags:
+        - event
       summary: Retrieve single event by id
       operationId: event_retrieve
-      tags:
-      - event
+      parameters:
+        - name: id
+          in: path
+          description: Event identifier as defined in event schema
+          required: true
+          schema:
+            type: string
       responses:
         200:
           description: Single event object
-          schema:
-            $ref: '#/definitions/event'
-      parameters:
-      - name: id
-        in: path
-        type: string
-        description: Event identifier as defined in event schema
-        required: true
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/event"
     put:
-      summary: Update an event
-      description: Events can be updated if the user has appropriate access permissions. The original implementation behaves like PATCH, ie. if some field is left out from the PUT call, its value is retained in database. In order to ensure consistent behaviour, users should always supply every field in PUT call.
-      operationId: event_update
       tags:
-      - event
+        - event
+      summary: Update an event
+      description:
+        Events can be updated if the user has appropriate access permissions.
+        The original implementation behaves like PATCH, ie. if some field is left out from the PUT call, its value is retained in database. In order to ensure consistent behaviour, users should always supply every field in PUT call.
+      operationId: event_update
+      parameters:
+        - name: id
+          in: path
+          description: Identifier for the event to be updated
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Event object that should replace the existing event, note that some implementations may retain unspecified fields at their original values.
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/event"
+        required: false
       responses:
         200:
-          description: Event has been succesfully replaced
-          schema:
-            $ref: '#/definitions/event'
+          description: Event has been succesfully replaced.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/event"
         400:
-          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed
+          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed.
+          content: {}
         401:
-          description: User was not authenticated
+          description: User was not authenticated.
+          content: {}
         403:
-          description: User does not have necessary permissions
-      parameters:
-      - type: string
-        in: path
-        name: id
-        required: true
-        description: Identifier for the event to be updated
-      - name: event_object
-        in: body
-        description: Event object that should replace the existing event, note that some implementations may retain unspecified fields at their original values.
-        schema:
-          $ref: '#/definitions/event'
+          description: User does not have necessary permissions.
+          content: {}
+      x-codegen-request-body-name: event_object
     delete:
-      summary: Delete an event
-      description: Events can be deleted if the user has appropriate access permissions.
-      operationId: event_delete
       tags:
-      - event
+        - event
+      summary: Delete an event
+      description: Event can be deleted if the user has appropriate access permissions.
+      operationId: event_delete
+      parameters:
+        - name: id
+          in: path
+          description: Identifier for the event to be deleted
+          required: true
+          schema:
+            type: string
       responses:
         204:
-          description: Event has been successfully deleted
+          description: Event has been successfully deleted.
+          content: {}
         401:
-          description: User was not authenticated
+          description: User was not authenticated.
+          content: {}
         403:
-          description: User does not have necessary permissions
-      parameters:
-      - type: string
-        in: path
-        name: id
-        required: true
-        description: Identifier for the event to be deleted
+          description: User does not have necessary permissions.
+          content: {}
+components:
+  schemas:
+    meta_definition:
+      title: Meta
+      type: object
+      properties:
+        count:
+          type: integer
+          description: Total amount of items found
+        next:
+          type: string
+          description: URL for the next page of items
+          format: url
+        previous:
+          type: string
+          description: URL for the previous page of items
+          format: url
+      description: Meta record for result pagination. All results from API are paginated, ie. delivered in chunks of X results. This records describes how many results there are in total, and how to access previous and next pages.
+    multilingual_object:
+      title: Multilingual object
+      type: object
+      properties:
+        fi:
+          type: string
+          description: value in Finnish
+        sv:
+          type: string
+          description: value in Swedish
+        en:
+          type: string
+          description: value in English
+        ar:
+          type: string
+          description: value in Arabic
+        ru:
+          type: string
+          description: value in Russian
+        zh_hans:
+          type: string
+          description: value in Chinase
+      description: Object for multilingual fields.
+    place:
+      title: Place
+      required:
+        - name
+        - position
+      type: object
+      properties:
+        id:
+          type: string
+          description: Consists of source prefix and source specific identifier. These should be URIs uniquely identifying the place, and preferably also well formed http-URLs pointing to more information about the place.
+        origin_id:
+          type: string
+          description: Place identifier in the originating system. Same as id but without the data source prefix.
+        data_source:
+          type: string
+          description:
+            Identifies the source for data, this is specific to API provider.
+            This is useful for API users, as any data quality issues are likely to be specific to data source and workarounds can be applied as such.
+        publisher:
+          type: string
+          description: Organization that provided the location data
+        created_time:
+          type: string
+          description: Creation time for the place entry
+          format: date-time
+          readOnly: true
+        last_modified_time:
+          type: string
+          description: Time this place was modified in the datastore behind the API (not necessarily in the originating system)
+          format: date-time
+          readOnly: true
+        created_by:
+          type: string
+          description: URL reference to the user that created this record (user endpoint)
+          readOnly: true
+        last_modified_by:
+          type: string
+          description: URL reference to the user that last modfied this record (user endpoint)
+          readOnly: true
+        custom_data:
+          type: array
+          description: |
+            Key value field for custom data. FIXME: is there 6Aika-wide use case for this?
+          items:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+        email:
+          type: string
+          description: Contact email for the place, note that this is NOT multilingual
+        contact_type:
+          type: string
+          description: |
+            FIXME: this seems unused in Helsinki data. Does any 6Aika city have use for describing contact type?
+        address_region:
+          type: string
+          description: Larger region for address (like states), not typically used in Finland
+        postal_code:
+          type: string
+          description: Postal code of the location (as used by traditional mail)
+        post_office_box_num:
+          type: string
+          description: PO box for traditional mail, in case mail is not delivered to the building
+        address_country:
+          type: string
+          description: Country for the place, NOT multilingual
+        deleted:
+          type: boolean
+          description: This place entry is not used anymore, but old events still reference it. This might be because of duplicate removal.
+        has_upcoming_events:
+          type: boolean
+          description: Tells if this place entry has any upcoming events.
+          readOnly: true
+        n_events:
+          type: boolean
+          description: Amount of events using this place entry as location.
+          readOnly: true
+        image:
+          type: integer
+          description: Id of the this place entry's image
+        parent:
+          $ref: "#/components/schemas/place"
+        replaced_by:
+          $ref: "#/components/schemas/place"
+        position:
+          type: object
+          properties:
+            coordinates:
+              type: array
+              description: Coordinates in format specified by type property
+              items:
+                type: number
+            type:
+              type: string
+              description: Interpretation of the coordinates property. Only point is supported in this version
+              enum:
+                - Point
+          description: Geographic position of the place specified using subset of GeoJSON
+        name:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              description: Name of the place, multilingual
+        street_address:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              description: Street address for the place, multilingual
+        info_url:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              properties:
+                fi:
+                  format: url
+                sv:
+                  format: url
+                en:
+                  format: url
+                ar:
+                  format: url
+                ru:
+                  format: url
+                zh_hans:
+                  format: url
+              description: Link (URL) to a page with more information about place
+        description:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              description: |
+                Short (? FIXME: perhaps specify recommendation) description of the place, multilingual.
+        address_locality:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              description: Describes where the address is located, typically this would be name of the city.
+        telephone:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              description: Contact phone number for the place, multilingual
+      description: Places describe physical locations for events and means for contacting people responsible for these locations. Place definitions come from organizations publishing events (field "publisher") and can thus have slightly different semantics between places sourced from different organizations.
+    image:
+      title: Image
+      required:
+        - url
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Identifier of the data source
+          readOnly: true
+        license:
+          type: string
+          description:
+            License data for the image. May be "cc_by" (default) or "event_only".
+            The latter license restricts use of the image and is specified on the API front page.
+        created_time:
+          type: string
+          description: Creation time for the image
+          format: date-time'
+          readOnly: true
+        last_modified_time:
+          type: string
+          description: Time this image was modified in the datastore behind the API (not necessarily in the originating system).
+          format: date-time
+          readOnly: true
+        created_by:
+          type: string
+          description: URL reference to the user that created this record (user endpoint)
+          readOnly: true
+        last_modified_by:
+          type: string
+          description: URL reference to the user that last modfied this record (user endpoint)
+          readOnly: true
+        name:
+          type: string
+          description: Image description
+        url:
+          type: string
+          description: The image file URL
+        cropping:
+          type: string
+          description: Cropping data for the image
+        photographer_name:
+          type: string
+          description: Photographer of the image
+        data_source:
+          type: string
+          description:
+            Identifies the source for data, this is specific to API provider.
+            This is useful for API users, as any data quality issues are likely to be specific to data source and workarounds can be applied as such.
+        publisher:
+          type: string
+          description: The organization responsible for the image
+        alt_text:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              description: The image alt text, multilingual.
+      description: Images are used as pictures for events, places and organizers.
+    organization:
+      title: Organization
+      required:
+        - id
+        - name
+        - data_source
+      type: object
+      properties:
+        id:
+          type: string
+          description: Consists of source prefix and source specific identifier. These should be URIs uniquely identifying the organization, and preferably also well formed http-URLs pointing to more information about the organization.
+        origin_id:
+          type: string
+          description:
+            Identifier for the organization in the original data source.
+            For standardized namespaces this will be a shared identifier.
+        data_source:
+          type: string
+          description:
+            Source of the organization data, typically API provider specific identifier.
+            Will also be used to specify standardized namespaces as they are brought into use.
+        classification:
+          type: string
+          description: Id of the organization type
+        name:
+          type: string
+          description: The name of the organization
+        founding_date:
+          type: string
+          description: Time the organization was founded
+          format: date-time
+        dissolution_date:
+          type: string
+          description: Time the organization was dissolved. If present, the organization no longer exists.
+          format: date-time
+        parent_organization:
+          $ref: "#/components/schemas/organization"
+        sub_organizations:
+          type: array
+          description: The organizations that belong to this organization.
+          items:
+            $ref: "#/components/schemas/organization"
+        affiliated_organizations:
+          type: array
+          description: The organizations that are affiliated partners to this organization, but not proper suborganizations.
+          items:
+            $ref: "#/components/schemas/organization"
+        created_time:
+          type: string
+          description: Creation time for the organization information
+          format: date-time
+          readOnly: true
+        last_modified_time:
+          type: string
+          description: Time this organization was modified in the datastore behind the API (not necessarily in the originating system)
+          format: date-time
+          readOnly: true
+        created_by:
+          type: string
+          description: URL reference to the user that created this record (user endpoint)
+          readOnly: true
+        last_modified_by:
+          type: string
+          description: URL reference to the user that last modfied this record (user endpoint)
+          readOnly: true
+        replaced_by:
+          $ref: "#/components/schemas/organization"
+        has_regular_users:
+          type: boolean
+          description: Whether the organization has non-admin users in addition to admin users
+        is_affiliated:
+          type: boolean
+          description: Whether the organization is an affiliated organization of the parent, instead of a proper suborganization
+      description: Organizations are the entities that publish events and other data.
+    organization_payload:
+      allOf:
+        - type: object
+          required:
+            - origin_id
+            - admin_users
+            - reguar_users
+          properties:
+            origin_id:
+              type: string
+              description:
+                Identifier for the organization in the data source of this organization.
+                For standardized namespaces this will be a shared identifier.
+            admin_users:
+              type: object
+              properties:
+                username:
+                  type: array
+                  description: Usernames of admin users
+                  items:
+                    type: string
+                    example: admin
+            regular_users:
+              type: object
+              properties:
+                username:
+                  type: array
+                  description: Usernames of regular users
+                  items:
+                    type: string
+                    example: regular
+            internal:
+              type: string
+        - $ref: "#/components/schemas/organization"
+    data_source:
+      title: Data source
+      type: object
+      properties:
+        id:
+          type: string
+          description: Identifier of the data source
+        name:
+          type: string
+          description: Identifier of the data source
+        user_editable_resources:
+          type: boolean
+          description: Boolean to define may resources be edited by users
+          example: false
+        user_editable_organizations:
+          type: boolean
+          description: Boolean to define may organizations be edited by users
+          example: true
+        edit_past_events:
+          type: boolean
+          description: Boolean to define may past events be created using API
+          example: false
+        create_past_events:
+          type: boolean
+          description: Boolean to define may past events be edited using API
+          example: false
+        private:
+          type: boolean
+          description: Boolean to define is data source private. By default events of private data source are hidden
+          example: false
+        owner:
+          type: string
+          description: Owner organization of the data source
+      description: Source of the data, typically API provider specific identifier. Will also be used to specify standardized namespaces as they are brought into use.
+    organization_class:
+      title: Organization class
+      type: object
+      properties:
+        id:
+          type: string
+          description: Consists of source prefix and source specific identifier.
+        name:
+          type: string
+          description: The name of the organization class
+        created_time:
+          type: string
+          description: Creation time for the organization class information
+          format: date-time
+        last_modified_time:
+          type: string
+          description: Time this organization class was modified
+          format: date-time
+        data_source:
+          type: string
+          description: Source of the organization data, typically API provider specific identifier. Will also be used to specify standardized namespaces as they are brought into use.
+      description: Organization classes are used for organization classification.
+    keyword:
+      title: Keyword
+      required:
+        - data_source
+        - id
+        - name
+      type: object
+      properties:
+        id:
+          type: string
+          description: Consists of source prefix and source specific identifier. These should be URIs uniquely identifying the keyword, and preferably also well formed http-URLs pointing to more information about the keyword.
+        origin_id:
+          type: string
+          description:
+            Identifier for the keyword in the organization using this keyword.
+            For standardized namespaces this will be a shared identifier.
+        alt_labels:
+          type: array
+          description: FIXME(verify) alternative labels for this keyword, no language specified. Use case?
+          items:
+            type: string
+        created_time:
+          type: string
+          description: Creation time for the keyword entry
+          format: date-time
+          readOnly: true
+        last_modified_time:
+          type: string
+          description: Time this place was modified in the datastore behind the API (not necessarily in the originating system)
+          format: date-time
+          readOnly: true
+        created_by:
+          type: string
+          description: FIXME(verify) URL reference to the user that created this record (user endpoint)
+          readOnly: true
+        last_modified_by:
+          type: string
+          description: FIXME(verify) URL reference to the user that last modfied this record (user endpoint)
+          readOnly: true
+        aggregate:
+          type: boolean
+          description: FIXME(verify) This keyword is an combination of several keywords at source
+        deprecated:
+          type: boolean
+          description: Whether this keyword has been deprecated in the original data source. It may still contain old events linked to it.
+        has_upcoming_events:
+          type: boolean
+          description: Tells if this keyword entry has any upcoming events
+          readOnly: true
+        n_events:
+          type: boolean
+          description: Amount of events using this keyword entry as a keyword or an audience
+          readOnly: true
+        image:
+          type: integer
+          description: Id of the this keyword entry's image
+        data_source:
+          type: string
+          description:
+            Source of the keyword, typically API provider specific identifier.
+            Will also be used to specify standardized namespaces as they are brought into use.
+        publisher:
+          type: string
+          description: Id of the organization that has originally published this keyword.
+        replaced_by:
+          $ref: "#/components/schemas/keyword"
+        name:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              description: Keyword name, multilingual
+      description: |
+        Keywords are used to describe events. Linked events uses namespaced
+        keywords in order to support having events from different sources. Namespaces
+        are needed because keywords are defined by the organization sourcing the events
+        and can therefore overlap in meaning. Conversely the meaning of same keyword
+        can vary between organizations. Organization sourcing the keyword can be identified
+        by data_source field. Data_source field will later specify standardized namespaces
+        as well.
+    keyword_set:
+      title: Keyword set
+      required:
+        - id
+        - keywords
+        - name
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier for this keyword set.
+            These should be URIs identifying the source and the keyword set itself, and preferably also well formed http-URLs pointing to more information about the keyword.
+        origin_id:
+          type: string
+          description: Set identifier in the originating system, if any
+        keywords:
+          type: array
+          description: Keywords that belong to this keyword set
+          items:
+            $ref: "#/components/schemas/keyword"
+        usage:
+          type: string
+          description: |
+            Usage type for this keyword set. These are allow UIs to show the set in appropriate place. FIXME: set of types is not finalized by any stretch
+          enum:
+            - any
+            - keyword
+            - audience
+        created_time:
+          type: string
+          description: Time when this keyword set was created (ISO 8601)
+          format: date-time
+          readOnly: true
+        last_modified_time:
+          type: string
+          description: Time when this keyword set was last modified (ISO 8601)
+          format: date-time
+          readOnly: true
+        created_by:
+          type: string
+          description: URL reference to the user that created this record (user endpoint)
+          readOnly: true
+        last_modified_by:
+          type: string
+          description: URL reference to the user that last modfied this record (user endpoint)
+          readOnly: true
+        image:
+          type: integer
+          description: Id of the this keyword set entry's image
+        data_source:
+          type: string
+          description: Unique identifier (URI)for the system where this keyword set originated, if any
+        organization:
+          type: string
+          description: Organization that has defined this keyword set
+        name:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+          description: Name for this keyword set, multilingual. This should be human readable, such that it could be shown as label in UI.
+      description: Keyword sets are used to group keywords together into classification groups. For example, one set of keywords might describe themes used by an event provider and another could be used to describe audience groups.
+    language:
+      title: Languages supported in this API
+      required:
+        - id
+        - name
+      type: object
+      properties:
+        id:
+          type: string
+          description: Identifier for the language (typically ISO639-1)
+        translation_available:
+          type: boolean
+          description:
+            Event data may have translations in the languages which have
+            <code>translation_available</code> set to <code>true</code>.
+          readOnly: true
+        name:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+          description: Translation for the language name. Properties shown here are examples, it is suggested that every language supported has its name translated to every other language. Users of the API cannot rely on any translations being present.
+      description: Primary purpose of this endpoint is to allow users to identify which languages are supported for multilingual fields. It also has translations for the names of the languages.
+    event:
+      title: Event
+      required:
+        - keywords
+        - location
+        - name
+        - publication_status
+        - start_time
+      type: object
+      properties:
+        id:
+          type: string
+          description: consists of source prefix and source specific identifier. These should be URIs uniquely identifying the event, and preferably also well formed http-URLs pointing to more information about the event.
+        location:
+          $ref: "#/components/schemas/place"
+        keywords:
+          type: array
+          description: The keywords that describe the topic and type of this event
+          items:
+            $ref: "#/components/schemas/keyword"
+        super_event:
+          type: string
+          description: References the aggregate event containing this event
+        event_status:
+          type: string
+          description: As defined in schema.org/Event. Postponed events do not have a date set, rescheduled events have been moved to different date.
+          readOnly: true
+        type_id:
+          type: string
+          description: Event type. Current options are General (Event), Course and Volunteering.
+          enum:
+            - General
+            - Course
+            - Volunteering
+        publication_status:
+          type: string
+          description: Only available in POST/PUT. Specifies whether the event should be published in the API ('public') or not ('draft').
+          enum:
+            - draft
+            - public
+        external_links:
+          type: array
+          description: See external link definition
+          items:
+            $ref: "#/components/schemas/eventlink"
+        offers:
+          type: array
+          description: See offer definition
+          items:
+            $ref: "#/components/schemas/offer"
+        data_source:
+          type: string
+          description: Unique identifier (URI)for the system from which this event came from, preferably URL with more information about the system and its policies.
+        publisher:
+          type: string
+          description: Id for the organization that published this event in Linkedevents.
+        sub_events:
+          type: array
+          description:
+            For aggregate events this contains references to all sub events.
+            Usually this means that the sub events are part of series. The field 'super_event_type' tells the type of the aggregate event.
+          items:
+            $ref: "#/components/schemas/event"
+        images:
+          type: array
+          items:
+            $ref: "#/components/schemas/image"
+        videos:
+          type: array
+          items:
+            $ref: "#/components/schemas/video"
+        in_language:
+          type: array
+          description: The languages spoken or supported at the event
+          items:
+            $ref: "#/components/schemas/language"
+        audience:
+          type: array
+          description: The audience groups (picked from keywords) this event is intended for
+          items:
+            $ref: "#/components/schemas/keyword"
+        created_time:
+          type: string
+          description: Creation time for the event entry.
+          format: date-time
+          readOnly: true
+        last_modified_time:
+          type: string
+          description: Time this event was modified in the datastore behind the API (not necessarily in the originating system)
+          format: date-time
+          readOnly: true
+        created_by:
+          type: string
+          description: Name and email of the user who created this event. Only available for authorized users in the publisher organization hierarchy.
+          readOnly: true
+        last_modified_by:
+          type: string
+          description: Name and email of the user who last edited this event. Only available for authorized users in the publisher organization hierarchy.
+          readOnly: true
+        date_published:
+          type: string
+          description: Date this event is free to be published
+          format: date-time
+        start_time:
+          type: string
+          description: Time the event will start
+          format: date-time
+        end_time:
+          type: string
+          description: Time the event will end
+          format: date-time
+        custom_data:
+          type: string
+          description: |
+            Key value field for custom data.
+        user_name:
+          type: string
+          description: |
+            Name of the external user.
+        user_email:
+          type: string
+          description: |
+            Email of the external user.
+        user_phone_number:
+          type: string
+          description: |
+            Phone number of the external user.
+        user_organization:
+          type: string
+          description: |
+            Organization of the external user.
+        user_consent:
+          type: boolean
+          description: |
+            Consent to user information of the external user.
+        environment:
+          type: string
+          description: Environment of the event. Current options are in (Indoor) and out (Outdoor).
+          enum:
+            - in
+            - out
+        environmental_certificate:
+          type: string
+          description: |
+            Url of the environmental certificate.
+        audience_min_age:
+          type: integer
+          description: Minimum age of attendee
+          example: 8
+        audience_max_age:
+          type: integer
+          description: Maximum age of attendee
+          example: 18
+        super_event_type:
+          type: string
+          description:
+            If the event has sub_events, describes the type of the event.
+            Current options are 'null', 'recurring', which means a repeating event, and 'umbrella', which means a major event that has subevents.
+          enum:
+            - recurring
+            - umbrella
+        deleted:
+          type: boolean
+          description: Whether this event has been deleted in the original data source
+        maximum_attendee_capacity:
+          type: integer
+          description: Maximum number of people allowed to enrol for the course
+          example: 100
+        minimum_attendee_capacity:
+          type: integer
+          description: Minimum number of people required to enrol for the course
+          example: 10
+        enrolment_start_time:
+          type: string
+          format: date-time
+          description: Time enrolment for the event will start
+          example: 2023-08-01T02:00:00+03:00
+        enrolment_end_time:
+          type: string
+          format: date-time
+          description: Time enrolment for the event will end
+          example: 2023-08-31T02:00:00+03:00
+        local:
+          type: boolean
+          readOnly: true
+        replaced_by:
+          $ref: "#/components/schemas/event"
+        info_url:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              properties:
+                fi:
+                  format: url
+                sv:
+                  format: url
+                en:
+                  format: url
+                ar:
+                  format: url
+                ru:
+                  format: url
+                zh_hans:
+                  format: url
+              description: Link (URL) to a page with more information about event
+        name:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              description: Short descriptive name for the event, recommended limit 80 characters
+        provider:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              description: Description of who is responsible for the practical implementation of the event
+        location_extra_info:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              description: Unstructured extra info about location (like "eastern door of railway station")
+        short_description:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              description: Short description for the event, recommended limit 140 characters
+        description:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              description: Long description for the event, several chapters
+        provider_contact_info:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              description: Provide's contact information, multilingual
+      description: |
+        Describes the actual events. Linked events API supports organizing
+        events into hierarchies. This is implemented with collection events called
+        "super events". Super events are normal event objects, that reference contained
+        events in "sub_events" property. Currently there are two major use cases:
+        events such as "Helsinki Festival", which consist of unique events over a
+        span of time and recurring events such as theatrical productions with multiple
+        showings. It is implementation dependent how the grouping of events is done.
+        It should be noted that grouping might be automatic based on eg. event name
+        and thus group unrelated events together and miss related events. Users of
+        data are advised to prepare for this.
+    offer:
+      title: Price offer
+      type: object
+      properties:
+        is_free:
+          type: boolean
+          description: Whether the event is of free admission
+        description:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              description: Further description of the pricing
+        info_url:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              properties:
+                fi:
+                  format: url
+                sv:
+                  format: url
+                en:
+                  format: url
+                ar:
+                  format: url
+                ru:
+                  format: url
+                zh_hans:
+                  format: url
+              description: Link (URL) to a page with more information about offer
+        price:
+          allOf:
+            - $ref: "#/components/schemas/multilingual_object"
+            - type: object
+              description: Price of the event. These are not bare numbers but instead descriptions of the pricing scheme.
+
+      description: Information record for this event. The prices are not in a structured format and the format depends on information source. An exception to this is the case of free event. These are indicated using is_free flag, which is searchable.
+    eventlink:
+      title: Link to related information
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name describing contents of the link
+        link:
+          type: string
+          description: link to an external related entity
+        language:
+          type: string
+          description: language of the content behind the link
+      description: Links to entities that the event publisher considers related to this event. Eg. links to catering service available during theatrical production. The links will most likely point to unstructured content, ie. web pages suitable for human viewing.
+    video:
+      title: Event video
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name describing contents of the video
+        url:
+          type: string
+          description: Url to a video
+        alt_text:
+          type: string
+          description: The video alt text
+      description: Links to videos that the event publisher considers related to this event.
+
+  parameters:
+    include_param:
+      name: include
+      in: query
+      description: Embed given reference-type fields, comma-separated if several, directly into the response, otherwise they are returned as URI references.
+      schema:
+        type: string
+    page_param:
+      name: page
+      in: query
+      description: Request particular page in paginated results
+      schema:
+        type: integer
+    pagesize_param:
+      name: page_size
+      in: query
+      description: Request that server delivers <code>page_size</code> results in response. 100 is the maximum value for page_size.
+      schema:
+        type: integer
+    sort:
+      name: sort
+      in: query
+      description: Return the results in ascending or descending order by the named field. sorting is only supported for some string, integer and datetime fields.
+      schema:
+        type: string
+    event_admin_user_param:
+      name: admin_user
+      in: query
+      description: Search for events that authenticated user can edit, including drafts, but no other public events
+      schema:
+        type: boolean
+    event_all_ongoing_AND_param:
+      name: all_ongoing_AND
+      in: query
+      description: Search for local and internet events that are upcoming or have not ended yet. Multiple search terms are separated by comma.
+      schema:
+        type: string
+    event_all_ongoing_OR_param:
+      name: all_ongoing_OR
+      in: query
+      description: Search for local and internet events that are upcoming or have not ended yet. Multiple search terms are separated by comma.
+      schema:
+        type: string
+    event_audience_max_age_lt_param:
+      name: audience_max_age_lt
+      in: query
+      description: Search for events whose maximum age is lower than or equals the specified value.
+      schema:
+        type: integer
+    event_audience_max_age_gt_param:
+      name: audience_max_age_gt
+      in: query
+      description: Search for events whose maximum age is greater than or equals the specified value.
+      schema:
+        type: integer
+    event_audience_min_age_lt_param:
+      name: audience_min_age_lt
+      in: query
+      description: Search for events whose minimal age is lower than or equals the specified value.
+      schema:
+        type: integer
+    event_audience_min_age_gt_param:
+      name: audience_min_age_gt
+      in: query
+      description: Search for events whose minimal age is greater than or equals the specified value.
+      schema:
+        type: integer
+    event_bbox_param:
+      name: bbox
+      in: query
+      description:
+        Search for events that are within this bounding box. Decimal coordinates are given in order west, south, east, north. Period is used as decimal separator.
+        Coordinate system is EPSG:4326.
+      style: form
+      explode: false
+      schema:
+        maxItems: 4
+        minItems: 4
+        type: array
+        items:
+          type: string
+    event_combined_text_param:
+      name: combined_text
+      in: query
+      description: Search for events with exact text match for event text fields but retrieves expected keywords on the basis of similarity.
+      schema:
+        type: string
+    event_created_by_param:
+      name: created_by
+      in: query
+      description: Search for events created by the authenticated user.
+      schema:
+        type: boolean
+    event_data_source_param:
+      name: data_source
+      in: query
+      description: Search for events that come from the specified source system.
+      schema:
+        type: string
+    event_days_param:
+      name: days
+      in: query
+      description: Search for events that intersect with the current time and specified amount of days from current time.
+      schema:
+        type: integer
+    event_division_param:
+      name: division
+      in: query
+      description: You may filter places by specific OCD division id, or by division name. The latter query checks all divisions with the name, regardless of division type.
+      schema:
+        type: string
+    event_dwithin_metres_param:
+      name: dwithin_metres
+      in: query
+      description: To restrict the retrieved events to a certain distance from a point, use the query parameters dwithin_origin and dwithin_metres in the format <code>dwithin_origin=lon,lat&dwithin_metres=distance</code>.
+      schema:
+        type: integer
+    event_dwithin_origin_param:
+      name: dwithin_origin
+      in: query
+      description: To restrict the retrieved events to a certain distance from a point, use the query parameters dwithin_origin and dwithin_metres in the format <code>dwithin_origin=lon,lat&dwithin_metres=distance</code>.
+      style: form
+      explode: false
+      schema:
+        maxItems: 2
+        minItems: 2
+        type: array
+        items:
+          type: string
+    event_end_param:
+      name: end
+      in: query
+      description: Search for events beginning or ending before this time. Dates can be specified using ISO 8601 ("2016-01-12") and additionally "today" and "now".
+      schema:
+        type: string
+        format: date-time
+    event_ends_after_param:
+      name: ends_after
+      in: query
+      description: Search for the events that ends after certain time.
+      schema:
+        type: string
+    event_ends_before_param:
+      name: ends_before
+      in: query
+      description: Search for the events that ends before certain time.
+      schema:
+        type: string
+    event_enrolment_open_param:
+      name: enrolment_open
+      in: query
+      description: Search for events that have connected registrations and have places at the event.
+      schema:
+        type: boolean
+    event_enrolment_open_waitlist_param:
+      name: enrolment_open_waitlist
+      in: query
+      description: Search for events that have connected registrations and have places in the waiting lists.
+      schema:
+        type: boolean
+    event_event_status_param:
+      name: event_status
+      in: query
+      description: Search for events with the specified status in the <code>event_status</code> field.
+      schema:
+        type: string
+    event_event_type_param:
+      name: event_type
+      in: query
+      description: Search for events with the specified type in the <code>type_id</code> field.
+      schema:
+        type: string
+    event_ids_param:
+      name: ids
+      in: query
+      description: Search for events with specific id, separating values by commas if you wish to query for several event ids.
+      schema:
+        type: string
+    event_in_language_param:
+      name: in_language
+      in: query
+      description: Search for events that are organized in this language.
+      schema:
+        type: string
+    event_internet_based_param:
+      name: internet_based
+      in: query
+      description: Search only for events that happen in the internet.
+      schema:
+        type: boolean
+    event_internet_ongoing_AND_param:
+      name: internet_ongoing_AND
+      in: query
+      description: Search for internet events that are upcoming or have not ended yet. Multiple search terms are separated by comma.
+      schema:
+        type: string
+    event_internet_ongoing_OR_param:
+      name: internet_ongoing_OR
+      in: query
+      description: Search for internet events that are upcoming or have not ended yet. Multiple search terms are separated by comma.
+      schema:
+        type: string
+    event_is_free_param:
+      name: is_free
+      in: query
+      description: Search for events that have a price that is free, or not free.
+      schema:
+        type: boolean
+    event_keyword_param:
+      name: keyword
+      in: query
+      description: Search for events with given keywords as specified by id. Multiple ids are separated by comma.
+      schema:
+        type: string
+    event_keyword_AND_param:
+      name: keyword_AND
+      in: query
+      description: Search for events with all given keywords as specified by id. Multiple ids are separated by comma.
+      schema:
+        type: string
+    event_keyword_NOT_param:
+      name: keyword!
+      in: query
+      description: Search for events with given keywords not to be present as specified by id. Multiple ids are separated by comma.
+      schema:
+        type: string
+    event_keyword_set_AND_param:
+      name: keyword_set_AND
+      in: query
+      description: Search for events that contains any of the keywords of defined keyword set. Multiple keyword sets are separated by comma.
+      schema:
+        type: string
+    event_keyword_set_OR_param:
+      name: keyword_set_OR
+      in: query
+      description: Search for events that contains any of the keywords of defined keyword set. Multiple keyword sets are separated by comma.
+      schema:
+        type: string
+    event_language_param:
+      name: language
+      in: query
+      description: Search for events that have data or are organized in this language.
+      schema:
+        type: string
+    event_last_modified_param:
+      name: last_modified_since
+      in: query
+      description: Search for events that have been modified since or at this time.
+      schema:
+        type: string
+        format: dateTime
+    event_local_ongoing_AND_param:
+      name: local_ongoing_AND
+      in: query
+      description: Search for local events that are upcoming or have not ended yet. Multiple search terms are separated by comma.
+      schema:
+        type: string
+    event_local_ongoing_OR_param:
+      name: local_ongoing_OR
+      in: query
+      description: Search for local events that are upcoming or have not ended yet. Multiple search terms are separated by comma.
+      schema:
+        type: string
+    event_location_param:
+      name: location
+      in: query
+      description: Search for events in given locations as specified by id. Multiple ids are separated by comma.
+      schema:
+        type: string
+    event_max_duration_param:
+      name: max_duration
+      in: query
+      description: Search for events that are shorter than given time in seconds.
+      schema:
+        type: integer
+    event_min_duration_param:
+      name: min_duration
+      in: query
+      description: Search for events that are longer than given time in seconds.
+      schema:
+        type: integer
+    event_publication_status_param:
+      name: publication_status
+      in: query
+      description: Search for events with the given publication status. Multiple values are separated by comma.
+      schema:
+        type: string
+    event_publisher_param:
+      name: publisher
+      in: query
+      description:
+        Search for events published by the given organization as specified.
+        by id.
+      schema:
+        type: string
+    event_publisher_ancestor_param:
+      name: publisher_ancestor
+      in: query
+      description: Search for events published by any suborganization under the given organization as specified by id.
+      schema:
+        type: string
+    event_registration_param:
+      name: registration
+      in: query
+      description: Search for events with or without a registration.
+      schema:
+        type: boolean
+    event_show_all_param:
+      name: show_all
+      in: query
+      description: Search for events that authenticated user can edit, including drafts, and public non-editable events
+      schema:
+        type: boolean
+    event_show_deleted_param:
+      name: show_deleted
+      in: query
+      description: Include deleted events in the query.
+      schema:
+        type: boolean
+    event_sort_param:
+      name: sort
+      in: query
+      description: Sort the returned events in the given order. Possible sorting criteria are 'start_time', 'end_time', 'duration' and 'last_modified_time'. The default ordering is '-last_modified_time'.
+      schema:
+        type: string
+    event_start_param:
+      name: start
+      in: query
+      description: Search for events beginning or ending after this time. Dates can be specified using ISO 8601 ("2016-01-12") and additionally "today" and "now".
+      schema:
+        type: string
+        format: date-time
+    event_starts_after_param:
+      name: starts_after
+      in: query
+      description: Search for the events that starts after certain time.
+      schema:
+        type: string
+    event_starts_before_param:
+      name: starts_before
+      in: query
+      description: Search for the events that starts before certain time.
+      schema:
+        type: string
+    event_suitable_for_param:
+      name: suitable_for
+      in: query
+      description: Search for events that are suitable for the age or age range specified.
+      schema:
+        type: integer
+    event_super_event_param:
+      name: super_event
+      in: query
+      description: Search for events with the given superevent as specified by id, including none. Multiple ids are separated by comma.
+      schema:
+        type: string
+    event_super_event_type_param:
+      name: super_event_type
+      in: query
+      description:
+        Search for events with the given superevent type, including none.
+        Multiple types are separated by comma.
+      schema:
+        type: string
+    event_text_param:
+      name: text
+      in: query
+      description:
+        Search (case insensitive) through all multilingual text fields (name, description, short_description, info_url) of an event (every language).
+        Multilingual fields contain the text that users are expected to care about, thus multilinguality is useful discriminator.
+      schema:
+        type: string
+    event_translation_param:
+      name: translation
+      in: query
+      description: Search for events that have data in this language.
+      schema:
+        type: string
+
+    image_data_source_param:
+      name: data_source
+      in: query
+      description: Search for images that come from the specified source system. Multiple data sources are separated by comma.
+      schema:
+        type: string
+    image_publisher_param:
+      name: publisher
+      in: query
+      description: Search for images published by the given organization as specified by id. Multiple ids are separated by comma.
+      schema:
+        type: string
+    image_sort_param:
+      name: sort
+      in: query
+      description: Default ordering is descending order by <code>-last_modified_time</code>. You may also order results by <code>id</code> and <code>name</code>.
+      schema:
+        type: string
+    image_text_param:
+      name: text
+      in: query
+      description: Search images that contain a specific string.
+      schema:
+        type: string
+
+    keyword_data_source_param:
+      name: data_source
+      in: query
+      description: |
+        Search for keywords (**note**: NOT events) that come from the specified data source (see data source in keyword definition).
+      schema:
+        type: string
+    keyword_free_text_param:
+      name: free_text
+      in: query
+      description: While the code>text</code> search is looking for the keywords containg exact matches of the search string, <code>free_text</code> retrieves keywords on the basis of similarity. Results are sorted by similarity.
+      schema:
+        type: string
+    keyword_has_upcoming_event_param:
+      name: has_upcoming_event
+      in: query
+      description: To show only the keywords which are used in the upcoming events supply the <code>has_upcoming_events</code> query parameter.
+      schema:
+        type: boolean
+    keyword_show_all_keywords_param:
+      name: show_all_keywords
+      in: query
+      description: Show all keywords, including those that are not associated with any events. Otherwise such keywords are hidden. When show_all_keywords is specified, no other filter is applied, **except** <code>filter</code> and <code>text</code> (match for keywords beginning with string).
+      schema:
+        type: boolean
+    keyword_show_deprecated_param:
+      name: show_deprecated
+      in: query
+      description: Show all keywords, including those that are deprecated. By default such keywords are hidden. When show_all_keywords is specified, no other filter is applied, **except** <code>filter</code> and <code>text</code> (match for keywords beginning with string).
+      schema:
+        type: boolean
+    keyword_sort_param:
+      name: sort
+      in: query
+      description: Sort the returned keywords in the given order. Possible sorting criteria are <code>n_events</code>, <code>id</code>, <code>name</code>, <code>data_source</code>. The default ordering is <code>-data_source</code>, <code>-n_events</code>.
+      schema:
+        type: string
+    keyword_text_param:
+      name: text
+      in: query
+      description: |
+        Search for keywords (**note**: NOT events) that contain the given string. This applies even when show_all_keywords is specified.
+      schema:
+        type: string
+
+    keyword_set_text_param:
+      name: text
+      in: query
+      description: Search for keyword sets that contain the given string in name or id fields.
+      schema:
+        type: string
+    keyword_set_sort_param:
+      name: sort
+      in: query
+      description: Sort the returned keyword sets in the given order. Possible sorting criteria are <code>name</code>, <code>usage</code> and <code>data_source</code>.
+      schema:
+        type: string
+
+    organization_child_param:
+      name: child
+      in: query
+      description: Get the parent organization and all its ancestors for the given organization id.
+      schema:
+        type: string
+    organization_parent_param:
+      name: parent
+      in: query
+      description: Get all suborganizations and their descendants for the given organization id.
+      schema:
+        type: string
+
+    place_data_source_param:
+      name: data_source
+      in: query
+      description: Search for places that come from the specified source system.
+      schema:
+        type: string
+    place_division_param:
+      name: division
+      in: query
+      description: You may filter places by specific OCD division id, or by division name. The latter query checks all divisions with the name, regardless of division type.
+      schema:
+        type: string
+    place_has_upcoming_event_param:
+      name: has_upcoming_event
+      in: query
+      description: To show only the places which are used in the upcoming events supply the <code>has_upcoming_events</code> query parameter.
+      schema:
+        type: boolean
+    place_show_all_places_param:
+      name: show_all_places
+      in: query
+      description: Show all places, including those that are not hosting any events. Otherwise such places are hidden. When show_all_places is specified, no other filter is applied.
+      schema:
+        type: boolean
+    place_show_deleted_param:
+      name: show_deleted
+      in: query
+      description: Show all keywords, including those that are deleted. By default such keywords are hidden.
+      schema:
+        type: boolean
+    place_sort_param:
+      name: sort
+      in: query
+      description: Sort the returned places in the given order. Possible sorting criteria are <code>n_events</code>, <code>id</code>, <code>name</code>, <code>street_address</code> and <code>postal_code</code>. The default ordering is <code>-n_events</code>.
+      schema:
+        type: string
+    place_text_param:
+      name: text
+      in: query
+      description: Search for places that contain the given string. This applies even when show_all_places is specified.
+      schema:
+        type: string

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -680,6 +680,32 @@ definitions:
       publisher:
         type: string
         description: Organization responsible for this event record.
+      extension_course:
+        type: object
+        description: Linked Courses extra fields
+        properties:
+          enrolment_start_time:
+            type: string
+            format: date-time
+            description: Time enrolment for the course will start
+            example: "2018-08-01T08:00:00Z"
+          enrolment_end_time:
+            type: string
+            format: date-time
+            description: Time enrolment for the course will end
+            example: "2018-08-31T18:00:00Z"
+          maximum_attendee_capacity:
+            type: integer
+            description: Maximum number of people allowed to enrol for the course
+            example: 100
+          minimum_attendee_capacity:
+            type: integer
+            description: Minimum number of people required to enrol for the course
+            example: 10
+          remaining_attendee_capacity:
+            type: integer
+            description: Number of people still allowed to enrol for the course before it is full
+            example: 50
   offer:
     title: Price offers
     description: information record for this event. The prices are not in a structured format and the format depends on information source. An exception to this is the case of free event. These are indicated using is_free flag, which is searchable.

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -66,7 +66,7 @@ parameters:
     name: sort
     in: query
     type: string
-    description: Sort the returned events in the given order. Possible sorting criteria are 'start_time', 'end_time', 'days_left' and 'last_modified_time'. The default ordering is '-last_modified_time'.
+    description: Sort the returned events in the given order. Possible sorting criteria are 'start_time', 'end_time', 'duration' and 'last_modified_time'. The default ordering is '-last_modified_time'.
   place_sort_param:
     name: sort
     in: query

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -1268,7 +1268,6 @@ paths:
         <pre><code>event/?sort=end_time
         </code></pre>
         <p><a href="?sort=name" title="json">See the result</a></p>
-    </div>
       operationId: Event_list
       tags:
       - event

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -658,7 +658,7 @@ definitions:
         description: references the aggregate event containing this event
         type: string
       super_event_type:
-        description: If the event has sub_events, describes the type of the event. Current options are 'null' and 'recurring', which means a repeating event.
+        description: If the event has sub_events, describes the type of the event. Current options are 'null', 'recurring', which means a repeating event, and 'umbrella', which means a major event that has subevents.
         type: string
       event_status:
         type: string

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -1681,8 +1681,8 @@ paths:
         description: Event objects that should replace the existing events. Each object must have id field that refers to an existing event.
         schema:
           type: array
-            items:
-              $ref: '#/definitions/event'
+          items:
+            $ref: '#/definitions/event'
 
   /event/{id}/:
     get:

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -1351,7 +1351,6 @@ paths:
         type: string
         description: 'You may filter places by specific OCD division id, or by division name. The latter query checks all divisions with the name, regardless of division type.'
       - $ref: '#/parameters/event_keyword_param'
-      - $ref: '#/parameters/event_recurring_param'
       - $ref: '#/parameters/event_min_duration_param'
       - $ref: '#/parameters/event_max_duration_param'
       - $ref: '#/parameters/event_organization_param'

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -1667,8 +1667,8 @@ paths:
           description: Events have been successfully updated
           schema:
             type: array
-              items:
-                $ref: '#/definitions/event'
+            items:
+              $ref: '#/definitions/event'
         400:
           description: Input format was not correct, eg. mandatory field was missing or JSON was malformed
         401:

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -33,9 +33,9 @@ produces:
 
 tags:
   - name: event
-    description: Search and Edit events
+    description: Search and edit events
   - name: filter
-    description: Search for keywords and places for filtering events
+    description: Browse keywords, places and publishers for filtering events
   - name: search
     description: Fulltext search through events and places
   - name: language
@@ -430,7 +430,66 @@ definitions:
         type: string
         description: License data for the image. May be "cc_by" (default) or "event_only". The latter license restricts use of the image and is specified on the API front page.
 
-
+  organization:
+    title: Organization
+    description: Organizations are the entities that publish events.
+    type: object
+    required:
+    - id
+    - name
+    - data source
+    properties:
+      id:
+        type: string
+        description: Consists of source prefix and source specific identifier. These should be URIs uniquely identifying the organization, and preferably also well formed http-URLs pointing to more information about the organization.
+      name:
+        type: string
+        description: The name of the organization.
+      origin_id:
+        type: string
+        description: Identifier for the organization in the original data source. For standardized namespaces this will be a shared identifier.
+      created_time:
+        type: string
+        format: date-time
+        description: 'Creation time for the organization information.'
+      last_modified_time:
+        type: string
+        format: date-time
+        description: 'Time this organization was modified in the datastore behind the API (not necessarily in the originating system)'
+      data_source:
+        type: string
+        description: Source of the organization data, typically API provider specific identifier. Will also be used to specify standardized namespaces as they are brought into use.
+      classification:
+        type: string
+        description: Id of the organization type.
+      founding_date:
+        type: string
+        format: date-time
+        description: 'Time the organization was founded.'
+      dissolution_date:
+        type: string
+        format: date-time
+        description: 'Time the organization was dissolved. If present, the organization no longer exists.'
+      is_affiliated:
+        type: boolean
+        description: Whether the organization is an affiliated organization of the parent, instead of a proper suborganization.
+      replaced_by:
+        "$ref": '#/definitions/organization'
+      has_regular_users:
+        type: boolean
+        description: Whether the organization has non-admin users in addition to admin users.
+      parent_organization:
+        "$ref": '#/definitions/organization'
+      sub_organizations:
+        type: array
+        description: The organizations that belong to this organization.
+        items:
+          "$ref": '#/definitions/organization'
+      affiliated_organizations:
+        type: array
+        description: The organizations that are affiliated partners to this organization, but not proper suborganizations.
+        items:
+          "$ref": '#/definitions/organization'
 
   keyword:
     title: Keyword
@@ -685,7 +744,7 @@ definitions:
         description: Date this event is free to be published
       provider:
         type: object
-        description: organization responsible for the practical implementation of the event
+        description: Description of who is responsible for the practical implementation of the event
         properties:
           fi:
             description: provider name in Finnish for the event
@@ -1108,6 +1167,59 @@ paths:
           description: Keyword_set record
           schema:
             $ref: '#/definitions/keyword_set'
+
+  /organization/:
+    get:
+      summary: Returns a list of organizations that publish events
+      description: |
+        <h2 id="using-organization-endpoint">Using the organization endpoint</h2>
+        <p>Here, the event publisher organizations are listed. Events published by each organization
+            can be found at the <code>event</code> endpoint using the query parameter <code>publisher</code>.</p>
+      operationId: organization_list
+      tags:
+      - filter
+      parameters:
+        - $ref: '#/parameters/page_param'
+        - $ref: '#/parameters/pagesize_param'
+        - name: child
+          in: query
+          type: string
+          description: 'Get the parent organization and all its ancestors for the given organization id.'
+        - name: parent
+          in: query
+          type: string
+          description: 'Get all suborganizations and their descendants for the given organization id.'
+
+      responses:
+        200:
+          description: List of organizations
+          schema:
+            type: object
+            properties:
+              meta:
+                $ref: '#/definitions/meta_definition'
+              data:
+                type: array
+                items:
+                  $ref: '#/definitions/organization'
+
+  /organization/{id}:
+    get:
+      summary: Return information for single organization
+      operationId: organization_retrieve
+      tags:
+      - filter
+      responses:
+        200:
+          description: Organization record
+          schema:
+            $ref: '#/definitions/organization'
+      parameters:
+      - type: string
+        description: Same as id in organization schema
+        in: path
+        name: id
+        required: true
 
   /place/:
     get:

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -1653,8 +1653,8 @@ paths:
         in: body
         schema:
           type: array
-            items:
-              $ref: '#/definitions/event'
+          items:
+            $ref: '#/definitions/event'
 
     put:
       summary: Bulk update several events

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -1629,13 +1629,13 @@ paths:
       - $ref: '#/parameters/event_sort_param'
 
     post:
-      summary: Create a new event
+      summary: Create a new event or events
       operationId: event_create
       tags:
       - event
       responses:
         201:
-          description: Object has been succesfully created. A copy of the object is returned in response body and headers contain Location pointing to the created event
+          description: Object(s) has/have been succesfully created. A copy of the object(s) is returned in response body and headers contain Location pointing to the created event
           schema:
             $ref: '#/definitions/event'
         400:
@@ -1649,6 +1649,40 @@ paths:
         in: body
         schema:
           $ref: '#/definitions/event'
+      - name: event_objects
+        in: body
+        schema:
+          type: array
+            items:
+              $ref: '#/definitions/event'
+
+    put:
+      summary: Bulk update several events
+      description: Events can be updated if the user has appropriate access permissions. The original implementation behaves like PATCH, ie. if some field is left out from the PUT call, its value is retained in database. In order to ensure consistent behaviour, users should always supply every field in PUT call.
+      operationId: event_bulk_update
+      tags:
+      - event
+      responses:
+        200:
+          description: Events have been successfully updated
+          schema:
+            type: array
+              items:
+                $ref: '#/definitions/event'
+        400:
+          description: Input format was not correct, eg. mandatory field was missing or JSON was malformed
+        401:
+          description: User was not authenticated
+        403:
+          description: User does not have necessary permissions for all referred events
+      parameters:
+      - name: event_objects
+        in: body
+        description: Event objects that should replace the existing events. Each object must have id field that refers to an existing event.
+        schema:
+          type: array
+            items:
+              $ref: '#/definitions/event'
 
   /event/{id}/:
     get:
@@ -1695,3 +1729,22 @@ paths:
         description: Event object that should replace the existing event, note that some implementations may retain unspecified fields at their original values.
         schema:
           $ref: '#/definitions/event'
+    delete:
+      summary: Delete an event
+      description: Events can be deleted if the user has appropriate access permissions.
+      operationId: event_delete
+      tags:
+      - event
+      responses:
+        204:
+          description: Event has been successfully deleted
+        401:
+          description: User was not authenticated
+        403:
+          description: User does not have necessary permissions
+      parameters:
+      - type: string
+        in: path
+        name: id
+        required: true
+        description: Identifier for the event to be deleted

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -80,10 +80,8 @@ parameters:
   include_param:
     name: include
     in: query
-    type: array
-    items:
-      type: string
-    description: Embed given reference-type fields directly into the response, otherwise they are returned as URI references.
+    type: string
+    description: Embed given reference-type fields, comma-separated if several, directly into the response, otherwise they are returned as URI references.
   event_text_param:
     name: text
     in: query
@@ -145,9 +143,7 @@ parameters:
   event_location_param:
     name: location
     in: query
-    type: array
-    items:
-      type: integer
+    type: string
     description: Search for events in given locations as specified by id. Multiple ids are separated by comma
   event_keyword_param:
     name: keyword
@@ -264,7 +260,7 @@ definitions:
           "$ref": '#/definitions/image'
       origin_id:
         type: string
-        description: 'Place identifier in the originating system, these should be in same format as id but variations are more likely than with id.'
+        description: 'Place identifier in the originating system. Same as id but without the data source prefix.'
       created_time:
         type: string
         format: date-time
@@ -434,7 +430,7 @@ definitions:
 
   organization:
     title: Organization
-    description: Organizations are the entities that publish events.
+    description: Organizations are the entities that publish events and other data.
     type: object
     required:
     - id
@@ -524,6 +520,9 @@ definitions:
       origin_id:
         type: string
         description: Identifier for the keyword in the organization using this keyword. For standardized namespaces this will be a shared identifier.
+      publisher:
+        type: string
+        description: Id of the organization that has originally published this keyword.
       created_time:
         type: string
         format: date-time
@@ -644,11 +643,10 @@ definitions:
       location:
         "$ref": '#/definitions/place'
       keywords:
-        description: array of keyword uri references
+        description: The keywords that describe the topic and type of this event.
         type: array
         items:
-          type: string
-          format: uri
+          "$ref": '#/definitions/keyword'
       in_language:
         description: the languages spoken or supported at the event
         type: array
@@ -679,7 +677,7 @@ definitions:
       sub_events:
         type: array
         items:
-          type: string
+          "$ref": '#/definitions/event'
         description: for aggregate events this contains references to all sub events. Usually this means that the sub events are part of series. The field 'super_event_type' tells the type of the aggregate event.
       custom_data:
         type: string
@@ -727,7 +725,7 @@ definitions:
             format: url
       description:
         type: object
-        description: Description for the event, several chapters(FIXME, verify)
+        description: Long description for the event, several chapters
         properties:
           fi:
             description: Finnish description of the event
@@ -778,6 +776,7 @@ definitions:
         format: date-time
         description: Time the event will end
       audience:
+        description: The audience groups (picked from keywords) this event is intended for
         type: array
         items:
           "$ref": '#/definitions/keyword'
@@ -786,13 +785,13 @@ definitions:
         description: Unique identifier (URI)for the system from which this event came from, preferably URL with more information about the system and its policies
       created_by:
         type: string
-        description: FIXME(verify) Which API user created this keyword
+        description: Name and email of the user who created this event. Only available for authorized users in the publisher organization hierarchy.
       last_modified_by:
         type: string
-        description: FIXME(verify) Which API user most recently edited this keyword
+        description: Name and email of the user who last edited this event. Only available for authorized users in the publisher organization hierarchy.
       publisher:
         type: string
-        description: Organization responsible for this event record.
+        description: Id for the organization that published this event in Linkedevents.
       deleted:
         type: boolean
         description: Whether this event has been deleted in the original data source.


### PR DESCRIPTION
# Description
- Update image filtering parameters and add endpoint to delete images
- Add endpoints to list and retrieve organization classes
- Add endpoints to list and retrieve data sources
- Add missing filtering params to keywords list endpoint and add post, put and delete methods
- Add missing filtering params to keyword sets list endpoint and add post, put and delete methods
- Add missing filtering params to places list endpoint and add post, put and delete methods
- Add missing filtering params to organizations list endpoint and add post, put and delete methods
- Add missing properties to place, organization, keyword, keyword set and event schemas and reorder properties to match api response
- Add event fields which external user is using to event schema